### PR TITLE
[irdl] Implement custom parsing and printing of IRDL

### DIFF
--- a/dyn-opt/dyn-opt.cpp
+++ b/dyn-opt/dyn-opt.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Dyn/Dialect/IRDL/IR/IRDL.h"
 #include "Dyn/DynamicContext.h"
 #include "Dyn/DynamicDialect.h"
 #include "MlirOptMain.h"
@@ -35,6 +36,7 @@ int main(int argc, char **argv) {
   // Register the standard dialect using DialectRegistry.
   DialectRegistry &registry = ctx.getDialectRegistry();
   registry.insert<StandardOpsDialect>();
+  registry.insert<irdl::IRDLDialect>();
 
   return failed(
       mlir::MlirOptMain(argc, argv, "Dyn optimizer driver\n", dynCtx));

--- a/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
@@ -139,7 +139,8 @@ def IRDL_OperationOp : IRDL_Op<"operation"> {
   }];
 
   let arguments = (ins StrAttr:$name);
-  let assemblyFormat = "attr-dict $name";
+  let printer = [{ ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
 }
 
 

--- a/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
@@ -110,7 +110,8 @@ def IRDL_TypeOp : IRDL_Op<"type"> {
   }];
 
   let arguments = (ins StrAttr:$name);
-  let assemblyFormat = "attr-dict $name";
+  let printer = [{ ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
@@ -77,7 +77,9 @@ def IRDL_DialectOp : IRDL_Op<"dialect", [
 
   let arguments = (ins StrAttr:$name);
   let regions = (region SizedRegion<1>:$body);
-  let assemblyFormat = "attr-dict $name $body";
+  let printer = [{ ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+  let verifier = [{ return ::verify(*this); }];
 }
 
 def IRDL_EndDialectOp : IRDL_Op<"end_dialect", [Terminator]> {

--- a/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
@@ -86,6 +86,29 @@ static void print(OpAsmPrinter &p, TypeOp typeOp) {
 }
 
 //===----------------------------------------------------------------------===//
+// irdl::OperationOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseOperationOp(OpAsmParser &p, OperationState &state) {
+  Builder &builder = p.getBuilder();
+
+  // Parse the operation name.
+  StringRef name;
+  if (failed(p.parseKeyword(&name)))
+    return failure();
+  state.addAttribute("name", builder.getStringAttr(name));
+
+  return success();
+}
+
+static void print(OpAsmPrinter &p, OperationOp operationOp) {
+  p << OperationOp::getOperationName() << " ";
+
+  // Print the operation name.
+  p << operationOp.name();
+}
+
+//===----------------------------------------------------------------------===//
 // IRDL operations.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
@@ -63,6 +63,29 @@ static void print(OpAsmPrinter &p, DialectOp dialectOp) {
 }
 
 //===----------------------------------------------------------------------===//
+// irdl::TypeOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseTypeOp(OpAsmParser &p, OperationState &state) {
+  Builder &builder = p.getBuilder();
+
+  // Parse the type name.
+  StringRef name;
+  if (failed(p.parseKeyword(&name)))
+    return failure();
+  state.addAttribute("name", builder.getStringAttr(name));
+
+  return success();
+}
+
+static void print(OpAsmPrinter &p, TypeOp typeOp) {
+  p << TypeOp::getOperationName() << " ";
+
+  // Print the type name.
+  p << typeOp.name();
+}
+
+//===----------------------------------------------------------------------===//
 // IRDL operations.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dyn/cmath.irdl
+++ b/test/Dyn/cmath.irdl
@@ -6,11 +6,11 @@ module {
         // CHECK: irdl.type complex
         irdl.type complex
         irdl.type real
-        // CHECK: irdl.operation "make_complex"
-        irdl.operation "make_complex"
-        irdl.operation "mul"
-        irdl.operation "norm"
-        irdl.operation "get_real"
-        irdl.operation "get_imaginary"
+        // CHECK: irdl.operation make_complex
+        irdl.operation make_complex
+        irdl.operation mul
+        irdl.operation norm
+        irdl.operation get_real
+        irdl.operation get_imaginary
     }
 }

--- a/test/Dyn/cmath.irdl
+++ b/test/Dyn/cmath.irdl
@@ -3,9 +3,9 @@
 module {
     // CHECK-LABEL: irdl.dialect cmath {
     irdl.dialect cmath {
-        // CHECK: irdl.type "complex"
-        irdl.type "complex"
-        irdl.type "real"
+        // CHECK: irdl.type complex
+        irdl.type complex
+        irdl.type real
         // CHECK: irdl.operation "make_complex"
         irdl.operation "make_complex"
         irdl.operation "mul"

--- a/test/Dyn/cmath.irdl
+++ b/test/Dyn/cmath.irdl
@@ -1,7 +1,12 @@
+// RUN: dyn-opt %s | dyn-opt | FileCheck %s
+
 module {
-    irdl.dialect "cmath" {
+    // CHECK-LABEL: irdl.dialect cmath {
+    irdl.dialect cmath {
+        // CHECK: irdl.type "complex"
         irdl.type "complex"
         irdl.type "real"
+        // CHECK: irdl.operation "make_complex"
         irdl.operation "make_complex"
         irdl.operation "mul"
         irdl.operation "norm"

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -21,7 +21,7 @@ config.name = 'DYN'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.mlir', '.c']
+config.suffixes = ['.irdl', '.mlir', '.c']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
This removes the use of assemblyFormat in favor of custom parsing and printing.
IRDL ops format was also slightly changed, but no feature were added