### PR TITLE
[irdl] Add operation operands and result constraints

### DIFF
--- a/include/Dyn/Dialect/IRDL/IR/IRDL.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDL.h
@@ -13,6 +13,7 @@
 #ifndef DYN_DIALECT_IRDL_IR_IRDL_H_
 #define DYN_DIALECT_IRDL_IR_IRDL_H_
 
+#include "Dyn/Dialect/IRDL/IR/IRDLAttributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"

--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -13,9 +13,14 @@
 #ifndef DYN_DIALECT_IRDL_IR_IRDLATTRIBUTES_H_
 #define DYN_DIALECT_IRDL_IR_IRDLATTRIBUTES_H_
 
+#include "Dyn/DynamicContext.h"
+#include "Dyn/DynamicDialect.h"
+#include "Dyn/DynamicObject.h"
+#include "Dyn/DynamicType.h"
 #include "mlir/IR/AttributeSupport.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Operation.h"
 #include "llvm/ADT/Hashing.h"
 
 namespace mlir {
@@ -28,6 +33,34 @@ struct TypeConstraint {
 
   bool operator==(const TypeConstraint &o) const {
     return typeName == o.typeName;
+  }
+
+  LogicalResult verifyType(Operation *op, Type type, bool isOperand,
+                           unsigned pos, dyn::DynamicContext &ctx) {
+    auto dialectEnd = typeName.find('.');
+    assert(dialectEnd != std::string::npos);
+    auto dialectName = StringRef(typeName).substr(0, dialectEnd);
+    auto typeSubname = StringRef(typeName).substr(dialectEnd + 1);
+
+    auto dialectRes = ctx.lookupDialect(dialectName);
+    if (failed(dialectRes))
+      return op->emitError("dialect " + dialectName + " is not registered.");
+    auto *dialect = *dialectRes;
+
+    auto dynTypeRes = dialect->lookupType(typeSubname);
+    if (failed(dynTypeRes))
+      return op->emitError("type " + typeSubname +
+                           " is not registered in the dialect " + dialectName +
+                           ".");
+    auto *dynType = *dynTypeRes;
+
+    if (!dyn::DynamicType::isa(type, dynType)) {
+      auto argType = isOperand ? "operand" : "result";
+      return op->emitError(std::to_string(pos) + "nth " + argType +
+                           " should be of type " + typeName);
+    }
+
+    return success();
   }
 };
 

--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -1,0 +1,107 @@
+//===- IRDLAttributes.h - Attributes definition for IRDL --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the attributes used in the IRDL dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DIALECT_IRDL_IR_IRDLATTRIBUTES_H_
+#define DYN_DIALECT_IRDL_IR_IRDLATTRIBUTES_H_
+
+#include "mlir/IR/AttributeSupport.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "llvm/ADT/Hashing.h"
+
+namespace mlir {
+namespace irdl {
+
+/// A type constraint is for now only a type equality constraint represented by
+/// the type name.
+using TypeConstraint = std::string;
+
+/// Definition of an argument. An argument is either an operand or a result.
+/// It is represented by a name an a type constraint.
+using ArgDef = std::pair<std::string, TypeConstraint>;
+using ArgDefs = ArrayRef<ArgDef>;
+using OwningArgDefs = std::vector<ArgDef>;
+
+/// Definition of a dynamic operation type.
+/// It contains the definition of every operand and result.
+struct OpTypeDef {
+  ArgDefs operandDef, resultDef;
+
+  /// Get the number of operands.
+  std::size_t getNumOperands() const { return operandDef.size(); }
+
+  /// Return the operand definitions.
+  /// Each operand is defined by a name, and a type constraint.
+  ArgDefs getOperandDefinitions() const { return operandDef; }
+
+  /// Get the number of results.
+  std::size_t getNumResults() const { return resultDef.size(); }
+
+  /// Return the result definitions.
+  /// Each result is defined by a name, and a type constraint.
+  ArgDefs getResDefinitions() const { return resultDef; }
+
+  bool operator==(const OpTypeDef &o) const {
+    return o.operandDef == operandDef && o.resultDef == o.resultDef;
+  }
+};
+
+/// Storage for OpTypeDefAttr.
+struct OpTypeDefAttrStorage : public AttributeStorage {
+  using KeyTy = OpTypeDef;
+
+  OpTypeDefAttrStorage(ArgDefs operandDefs, ArgDefs resultDefs)
+      : opTypeDef({operandDefs, resultDefs}) {}
+
+  bool operator==(const KeyTy &key) const { return key == opTypeDef; }
+
+  static llvm::hash_code hashKey(const KeyTy &key) {
+    return llvm::hash_combine(key.operandDef, key.resultDef);
+  }
+
+  static KeyTy getKey(ArgDefs operandDefs, ArgDefs resultDefs) {
+    return KeyTy({operandDefs, resultDefs});
+  }
+
+  static OpTypeDefAttrStorage *
+  construct(mlir::AttributeStorageAllocator &allocator, const KeyTy &key) {
+    auto operandDefs = allocator.copyInto(key.operandDef);
+    auto resDefs = allocator.copyInto(key.resultDef);
+
+    return new (allocator.allocate<OpTypeDef>())
+        OpTypeDefAttrStorage({operandDefs, resDefs});
+  }
+
+  OpTypeDef opTypeDef;
+};
+
+/// Attribute representing the type definition of a dynamic operation.
+/// It contains a name and type constraints for each operand and result.
+class OpTypeDefAttr
+    : public mlir::Attribute::AttrBase<OpTypeDefAttr, mlir::Attribute,
+                                       OpTypeDefAttrStorage> {
+public:
+  /// Using Attribute constructors.
+  using Base::Base;
+
+  static OpTypeDefAttr get(MLIRContext &ctx, ArgDefs operandDefs,
+                           ArgDefs resultDefs) {
+    return Base::get(&ctx, operandDefs, resultDefs);
+  }
+
+  OpTypeDef getValue() { return getImpl()->opTypeDef; }
+};
+
+} // namespace irdl
+} // namespace mlir
+
+#endif // DYN_DIALECT_IRDL_IR_IRDL_H_

--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -23,7 +23,18 @@ namespace irdl {
 
 /// A type constraint is for now only a type equality constraint represented by
 /// the type name.
-using TypeConstraint = std::string;
+struct TypeConstraint {
+  std::string typeName;
+
+  bool operator==(const TypeConstraint &o) const {
+    return typeName == o.typeName;
+  }
+};
+
+/// Make type constraints hashable.
+inline llvm::hash_code hash_value(const TypeConstraint &constr) {
+  return llvm::hash_value(constr.typeName);
+}
 
 /// Definition of an argument. An argument is either an operand or a result.
 /// It is represented by a name an a type constraint.

--- a/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
@@ -118,6 +118,11 @@ def IRDL_TypeOp : IRDL_Op<"type"> {
 // IRDL Dialect definition
 //===----------------------------------------------------------------------===//
 
+def OpDefAttr : Attr<CPred<"$_self.isa<OpTypeDefAttr>()">, "OperationOp type constraints definition"> {
+  let storageType = "OpTypeDefAttr";
+  let returnType = "OpTypeDef";
+}
+
 def IRDL_OperationOp : IRDL_Op<"operation"> {
   let summary = "Define a new operation";
   let description = [{
@@ -135,10 +140,9 @@ def IRDL_OperationOp : IRDL_Op<"operation"> {
     ```
     
     The above program defines an operation `mul` inside the dialect `cmath`.
-
   }];
 
-  let arguments = (ins StrAttr:$name);
+  let arguments = (ins StrAttr:$name, OpDefAttr:$op_def);
   let printer = [{ ::print(p, *this); }];
   let parser = [{ return ::parse$cppClass(parser, result); }];
 }

--- a/include/Dyn/Dialect/IRDL/IR/TypeConstraint.h
+++ b/include/Dyn/Dialect/IRDL/IR/TypeConstraint.h
@@ -1,0 +1,45 @@
+//===- TypeConstraint.h - IRDL type constraint definition -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the different type constraints an operand or a result can
+// have.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DIALECT_IRDL_IR_TYPECONSTRAINT_H_
+#define DYN_DIALECT_IRDL_IR_TYPECONSTRAINT_H_
+
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/Hashing.h"
+
+namespace mlir {
+
+namespace dyn {
+// Forward declaration.
+class DynamicContext;
+} // namespace dyn
+
+namespace irdl {
+
+/// A type constraint is for now only a type equality constraint represented by
+/// the type name.
+struct TypeConstraint {
+  std::string typeName;
+
+  bool operator==(const TypeConstraint &o) const {
+    return typeName == o.typeName;
+  }
+
+  LogicalResult verifyType(Operation *op, Type type, bool isOperand,
+                           unsigned pos, dyn::DynamicContext &ctx);
+};
+} // namespace irdl
+} // namespace mlir
+
+#endif // DYN_DIALECT_IRDL_IR_TYPECONSTRAINT_H_

--- a/include/Dyn/DynamicContext.h
+++ b/include/Dyn/DynamicContext.h
@@ -79,7 +79,7 @@ private:
   TypeIDAllocator typeIDAllocator;
 
   /// The set of dynamically defined dialects.
-  llvm::StringMap<std::unique_ptr<DynamicDialect>> dialects;
+  llvm::StringMap<DynamicDialect *> dialects;
 
   /// This structure allows to get in O(1) a dynamic type given its typeID.
   llvm::DenseMap<TypeID, DynamicTypeDefinition *> typeIDToDynTypes{};

--- a/include/Dyn/DynamicContext.h
+++ b/include/Dyn/DynamicContext.h
@@ -70,6 +70,15 @@ public:
     return &*it->second;
   }
 
+  /// Get a dialect given its typeID.
+  /// The pointer is guaranteed to be non-null.
+  FailureOr<DynamicDialect *> lookupDialect(StringRef name) const {
+    auto it = dialects.find(name);
+    if (it == dialects.end())
+      return failure();
+    return &*it->second;
+  }
+
   /// We declare DynamicDialect friend so it can register types and operations
   /// in the context.
   friend DynamicDialect;

--- a/include/Dyn/DynamicContext.h
+++ b/include/Dyn/DynamicContext.h
@@ -28,6 +28,9 @@ class MLIRContext;
 namespace dyn {
 
 // Forward declaration.
+class DynamicTypeDefinition;
+
+// Forward declaration.
 class DynamicDialect;
 
 // Forward declaration.

--- a/include/Dyn/DynamicOperation.h
+++ b/include/Dyn/DynamicOperation.h
@@ -14,7 +14,6 @@
 #define DYN_DYNAMICOPERATION_H
 
 #include "Dyn/DynamicObject.h"
-#include "DynamicDialect.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include <mlir/IR/OpDefinition.h>

--- a/include/Dyn/DynamicType.h
+++ b/include/Dyn/DynamicType.h
@@ -13,7 +13,6 @@
 #ifndef DYN_DYNAMICTYPE_H
 #define DYN_DYNAMICTYPE_H
 
-#include "Dyn/DynamicContext.h"
 #include "DynamicObject.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/TypeSupport.h"
@@ -22,6 +21,7 @@
 namespace mlir {
 namespace dyn {
 
+// Forward declaration.
 class DynamicDialect;
 
 /// This is the definition of a dynamic type. It stores the parser and printer.

--- a/include/Dyn/DynamicType.h
+++ b/include/Dyn/DynamicType.h
@@ -22,6 +22,8 @@
 namespace mlir {
 namespace dyn {
 
+class DynamicDialect;
+
 /// This is the definition of a dynamic type. It stores the parser and printer.
 /// Each dynamic type instance refer to one instance of this class.
 class DynamicTypeDefinition : public DynamicObject {

--- a/lib/Dyn/Dialect/IRDL/CMakeLists.txt
+++ b/lib/Dyn/Dialect/IRDL/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(MLIRIRDL
         IR/IRDL.cpp
+        IR/TypeConstraint.cpp
         IRDLRegistration.cpp
 
         ADDITIONAL_HEADER_DIRS

--- a/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
@@ -103,14 +103,14 @@ ParseResult parseTypeConstraint(OpAsmParser &p,
   if (p.parseKeyword(&name))
     return failure();
 
-  *typeConstraint = name.str();
+  typeConstraint->typeName = name.str();
   return success();
 }
 
 /// Print a type constraint with the format "dialect.name".
 void printTypeConstraint(OpAsmPrinter &p,
                          const TypeConstraint &typeConstraint) {
-  p << typeConstraint;
+  p << typeConstraint.typeName;
 }
 
 /// Parse an ArgDef with format "name: typeConstraint".

--- a/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dyn/Dialect/IRDL/IR/IRDL.h"
+#include "Dyn/Dialect/IRDL/IR/IRDLAttributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Support/LogicalResult.h"
@@ -23,6 +24,7 @@ void IRDLDialect::initialize() {
 #define GET_OP_LIST
 #include "Dyn/Dialect/IRDL/IR/IRDLOps.cpp.inc"
       >();
+  addAttributes<OpTypeDefAttr>();
 }
 
 //===----------------------------------------------------------------------===//
@@ -86,6 +88,117 @@ static void print(OpAsmPrinter &p, TypeOp typeOp) {
 }
 
 //===----------------------------------------------------------------------===//
+// irdl::OpTypeDefAttr
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Parse a type constraint with the format "dialect.name".
+/// The verifier ensures that the format is respected. Only a keyword is parsed
+/// (since mlir will parse "." in keywords).
+ParseResult parseTypeConstraint(OpAsmParser &p,
+                                TypeConstraint *typeConstraint) {
+  StringRef name;
+
+  if (p.parseKeyword(&name))
+    return failure();
+
+  *typeConstraint = name.str();
+  return success();
+}
+
+/// Print a type constraint with the format "dialect.name".
+void printTypeConstraint(OpAsmPrinter &p,
+                         const TypeConstraint &typeConstraint) {
+  p << typeConstraint;
+}
+
+/// Parse an ArgDef with format "name: typeConstraint".
+ParseResult parseArgDef(OpAsmParser &p, ArgDef *argDef) {
+  StringRef name;
+  TypeConstraint typeConstraint;
+
+  if (p.parseKeyword(&name) || p.parseColon() ||
+      parseTypeConstraint(p, &argDef->second))
+    return failure();
+
+  argDef->first = name.str();
+  return success();
+}
+
+/// Print an ArgDef with format "name: typeConstraint".
+void printTypedVar(OpAsmPrinter &p, const ArgDef &argDef) {
+  p << argDef.first << ": ";
+  printTypeConstraint(p, argDef.second);
+}
+
+/// Parse an ArgDefs with format ([argDef,]*).
+/// The trailing comma is optional.
+ParseResult parseArgDefs(OpAsmParser &p, OwningArgDefs *argDefs) {
+  if (p.parseLParen())
+    return failure();
+
+  while (true) {
+    if (!p.parseOptionalRParen())
+      break;
+
+    ArgDef argDef;
+    if (parseArgDef(p, &argDef))
+      return failure();
+    argDefs->push_back(argDef);
+
+    if (!p.parseOptionalComma())
+      continue;
+
+    if (p.parseRParen())
+      return failure();
+
+    break;
+  }
+
+  return success();
+}
+
+void printArgDefs(OpAsmPrinter &p, ArgDefs typedVars) {
+  p << "(";
+  for (const auto &typedVar : typedVars) {
+    printTypedVar(p, typedVar);
+    p << ", ";
+  }
+  p << ")";
+}
+
+/// Parse an OpTypeDefAttr.
+/// The format is "operandDef -> resultDef" where operandDef and resultDef have
+/// the ArgDefs format.
+ParseResult parseOpTypeDefAttr(OpAsmParser &p, OpTypeDefAttr *opTypeDefAttr) {
+  OwningArgDefs operandDefs, resultDefs;
+  // Parse the operands.
+  if (parseArgDefs(p, &operandDefs))
+    return failure();
+
+  if (p.parseArrow())
+    return failure();
+
+  // Parse the results.
+  if (parseArgDefs(p, &resultDefs))
+    return failure();
+
+  *opTypeDefAttr =
+      OpTypeDefAttr::get(*p.getBuilder().getContext(), std::move(operandDefs),
+                         std::move(resultDefs));
+  return success();
+}
+
+void printOpTypeDef(OpAsmPrinter &p, OpTypeDef opDef) {
+  printArgDefs(p, opDef.operandDef);
+  p << " -> ";
+  printArgDefs(p, opDef.resultDef);
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // irdl::OperationOp
 //===----------------------------------------------------------------------===//
 
@@ -94,9 +207,15 @@ static ParseResult parseOperationOp(OpAsmParser &p, OperationState &state) {
 
   // Parse the operation name.
   StringRef name;
-  if (failed(p.parseKeyword(&name)))
+  if (p.parseKeyword(&name))
     return failure();
   state.addAttribute("name", builder.getStringAttr(name));
+
+  // Parse the OpDefAttr.
+  OpTypeDefAttr opTypeDef;
+  if (parseOpTypeDefAttr(p, &opTypeDef))
+    return failure();
+  state.addAttribute("op_def", opTypeDef);
 
   return success();
 }
@@ -106,6 +225,9 @@ static void print(OpAsmPrinter &p, OperationOp operationOp) {
 
   // Print the operation name.
   p << operationOp.name();
+
+  // Print the operation type constraints.
+  printOpTypeDef(p, operationOp.op_def());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dyn/Dialect/IRDL/IR/TypeConstraint.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/TypeConstraint.cpp
@@ -1,0 +1,52 @@
+//===- TypeConstraint.cpp - IRDL type constraint definition -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the different type constraints an operand or a result can
+// have.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dyn/Dialect/IRDL/IR/TypeConstraint.h"
+#include "Dyn/DynamicContext.h"
+#include "Dyn/DynamicDialect.h"
+
+using namespace mlir;
+using namespace dyn;
+using namespace irdl;
+
+LogicalResult TypeConstraint::verifyType(Operation *op, Type type,
+                                         bool isOperand, unsigned pos,
+                                         dyn::DynamicContext &ctx) {
+  auto dialectEnd = typeName.find('.');
+  assert(dialectEnd != std::string::npos);
+  auto dialectName = StringRef(typeName).substr(0, dialectEnd);
+  auto typeSubname = StringRef(typeName).substr(dialectEnd + 1);
+
+  /// Get the dialect owning the type.
+  auto dialectRes = ctx.lookupDialect(dialectName);
+  if (failed(dialectRes))
+    return op->emitError("dialect " + dialectName + " is not registered.");
+  auto *dialect = *dialectRes;
+
+  /// Get the type from the dialect.
+  auto dynTypeRes = dialect->lookupType(typeSubname);
+  if (failed(dynTypeRes))
+    return op->emitError("type " + typeSubname +
+                         " is not registered in the dialect " + dialectName +
+                         ".");
+  auto *dynType = *dynTypeRes;
+
+  /// Check for type equality
+  if (!dyn::DynamicType::isa(type, dynType)) {
+    auto argType = isOperand ? "operand" : "result";
+    return op->emitError(std::to_string(pos) + "nth " + argType +
+                         " should be of type " + typeName);
+  }
+
+  return success();
+}

--- a/lib/Dyn/Dialect/IRDL/IR/TypeConstraint.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/TypeConstraint.cpp
@@ -23,7 +23,9 @@ LogicalResult TypeConstraint::verifyType(Operation *op, Type type,
                                          bool isOperand, unsigned pos,
                                          dyn::DynamicContext &ctx) {
   auto dialectEnd = typeName.find('.');
-  assert(dialectEnd != std::string::npos);
+  if (dialectEnd == std::string::npos)
+    return op->emitError("type name should have the format dialect.name, " +
+                         typeName + " found.");
   auto dialectName = StringRef(typeName).substr(0, dialectEnd);
   auto typeSubname = StringRef(typeName).substr(dialectEnd + 1);
 

--- a/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
+++ b/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
@@ -16,6 +16,7 @@
 #include "Dyn/DynamicDialect.h"
 #include "mlir/IR/Visitors.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace mlir;
 using namespace irdl;
@@ -26,9 +27,65 @@ LogicalResult registerType(TypeOp typeOp, dyn::DynamicDialect *dialect) {
   return dialect->createAndAddType(typeOp.name());
 }
 
+/// Objects representing the type constraints of dynamic operations.
+/// Each operand and each result have a name, and a type constraint.
+using OpTypeConstraint = std::pair<std::string, TypeConstraint>;
+using OpTypeConstraints = std::pair<OwningArgDefs, OwningArgDefs>;
+
+LogicalResult verifyOpTypeConstraints(Operation *op,
+                                      const OpTypeConstraints &typeConstrs,
+                                      dyn::DynamicContext &ctx) {
+  auto operandConstrs = typeConstrs.first;
+  auto resultConstrs = typeConstrs.second;
+
+  /// Check that we have the right number of operands.
+  auto numOperands = op->getNumOperands();
+  auto numExpectedOperands = typeConstrs.first.size();
+  if (numOperands != numExpectedOperands)
+    return op->emitOpError(std::to_string(numExpectedOperands) +
+                           " operands expected, but got " +
+                           std::to_string(numOperands));
+
+  /// Check that we have the right number of results.
+  auto numResults = op->getNumResults();
+  auto numExpectedResults = typeConstrs.second.size();
+  if (numResults != numExpectedResults)
+    return op->emitOpError(std::to_string(numExpectedResults) +
+                           " results expected, but got " +
+                           std::to_string(numResults));
+
+  /// Check that all operands satisfy the constraints.
+  for (unsigned i = 0; i < numOperands; ++i) {
+    auto operandType = op->getOperand(i).getType();
+    auto constraint = operandConstrs[i].second;
+    if (failed(constraint.verifyType(op, operandType, i, true, ctx)))
+      return failure();
+  }
+
+  /// Check that all results satisfy the constraints.
+  for (unsigned i = 0; i < numResults; ++i) {
+    auto resultType = op->getResult(i).getType();
+    auto constraint = resultConstrs[i].second;
+    if (failed(constraint.verifyType(op, resultType, i, true, ctx)))
+      return failure();
+  }
+
+  return success();
+}
+
 /// Register an operation represented by a `irdl.operation` operation.
 LogicalResult registerOperation(OperationOp op, dyn::DynamicDialect *dialect) {
-  return dialect->createAndAddOperation(op.name());
+  OpTypeDef opDef = op.op_def();
+  OpTypeConstraints constraints =
+      make_pair(std::vector<ArgDef>(opDef.operandDef),
+                std::vector<ArgDef>(opDef.resultDef));
+
+  auto ctx = dialect->getDynamicContext();
+  auto typeVerifier = [constraints{std::move(constraints)},
+                       ctx](Operation *op) {
+    return verifyOpTypeConstraints(op, constraints, *ctx);
+  };
+  return dialect->createAndAddOperation(op.name(), {typeVerifier});
 }
 } // namespace
 

--- a/lib/Dyn/DynamicContext.cpp
+++ b/lib/Dyn/DynamicContext.cpp
@@ -46,5 +46,9 @@ DynamicContext::createAndRegisterDialect(llvm::StringRef name) {
   // llvm::cast cannot be used here, since we have a custom TypeID that does
   // not correspond to the TypeID statically assigned to the DynamicDialect
   // class.
-  return reinterpret_cast<DynamicDialect *>(dialect);
+  auto *dynDialect = reinterpret_cast<DynamicDialect *>(dialect);
+
+  dialects.insert({name, dynDialect});
+
+  return dynDialect;
 }

--- a/lib/Dyn/DynamicContext.cpp
+++ b/lib/Dyn/DynamicContext.cpp
@@ -13,6 +13,8 @@
 #include "Dyn/DynamicContext.h"
 #include "Dyn/DynamicDialect.h"
 #include "Dyn/DynamicOperation.h"
+#include "Dyn/DynamicType.h"
+#include "mlir/Support/LogicalResult.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/lib/Dyn/DynamicDialect.cpp
+++ b/lib/Dyn/DynamicDialect.cpp
@@ -43,6 +43,7 @@ DynamicDialect::createAndAddType(StringRef name) {
   DynamicTypeDefinition *type = registered.first->second.get();
   auto typeID = type->getRuntimeTypeID();
   typeIDToDynTypes.insert({typeID, type});
+  ctx->typeIDToDynTypes.insert({typeID, type});
 
   /// Add the type to the dialect and the type uniquer.
   addType(typeID,
@@ -63,6 +64,7 @@ FailureOr<DynamicOperation *> DynamicDialect::createAndAddOperation(
   DynamicOperation *absOp = registered.first->second.get();
   auto typeID = absOp->getRuntimeTypeID();
   typeIDToDynOps.insert({typeID, absOp});
+  ctx->typeIDToDynOps.insert({typeID, absOp});
 
   AbstractOperation::insert(
       absOp->getName(), *this, {}, absOp->getRuntimeTypeID(),

--- a/test/Dyn/cmath.irdl
+++ b/test/Dyn/cmath.irdl
@@ -6,11 +6,11 @@ module {
         // CHECK: irdl.type complex
         irdl.type complex
         irdl.type real
-        // CHECK: irdl.operation make_complex
-        irdl.operation make_complex
-        irdl.operation mul
-        irdl.operation norm
-        irdl.operation get_real
-        irdl.operation get_imaginary
+        // CHECK: irdl.operation make_complex(re: cmath.real, im: cmath.real, ) -> (res: cmath.complex, )
+        irdl.operation make_complex(re : cmath.real, im: cmath.real) -> (res: cmath.complex)
+        irdl.operation mul(lhs: cmath.complex, rhs: cmath.complex) -> (res: cmath.complex)
+        irdl.operation norm(c: cmath.complex) -> (res: cmath.real)
+        irdl.operation get_real(c: cmath.complex) -> (res: cmath.real)
+        irdl.operation get_imaginary(c: cmath.complex) -> (res: cmath.real)
     }
 }


### PR DESCRIPTION
This PR adds parsing/printing/verifying of operands/results constraints.
We can now define an operation like this:
```
irdl.operation make_complex(re: cmath.real, im: cmath.real) -> (res: cmath.complex)
```

The implementation is far from being optimal, and will be improved in further PRs.
The only type constraint there is for now is type equality.