### PR TITLE
Registration during parsing

### DIFF
--- a/dyn-opt/RegisterIRDL.cpp
+++ b/dyn-opt/RegisterIRDL.cpp
@@ -59,14 +59,5 @@ LogicalResult mlir::registerIRDL(StringRef irdlFile,
   // Parse the input file and reset the context threading state.
   OwningModuleRef module(parseSourceFile(sourceMgr, context));
   context->enableMultithreading(wasThreadingEnabled);
-  if (!module)
-    return failure();
-
-  auto res = module.get()->walk([&](irdl::DialectOp op) {
-    if (failed(irdl::registerDialect(op, dynContext)))
-      return WalkResult::interrupt();
-    return WalkResult::advance();
-  });
-
-  return failure(res.wasInterrupted());
+  return failure(!module);
 }

--- a/dyn-opt/dyn-opt.cpp
+++ b/dyn-opt/dyn-opt.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
@@ -31,7 +32,7 @@ int main(int argc, char **argv) {
   // TODO: Register passes here.
 
   MLIRContext ctx;
-  DynamicContext dynCtx(&ctx);
+  auto dynCtx = ctx.getOrLoadDialect<DynamicContext>();
 
   // Register the standard dialect and the IRDL dialect in the MLIR context
   DialectRegistry registry;
@@ -39,5 +40,5 @@ int main(int argc, char **argv) {
   ctx.appendDialectRegistry(registry);
 
   return failed(
-      mlir::MlirOptMain(argc, argv, "Dyn optimizer driver\n", dynCtx));
+      mlir::MlirOptMain(argc, argv, "Dyn optimizer driver\n", *dynCtx));
 }

--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -133,23 +133,6 @@ public:
 // IRDL Equality type constraint attribute
 //===----------------------------------------------------------------------===//
 
-/// Attribute for equality type constraint with a dynamic type. The dynamic type
-/// is represented by its name.
-class EqDynTypeConstraintAttr : public mlir::Attribute::AttrBase<
-                                    EqDynTypeConstraintAttr, mlir::Attribute,
-                                    mlir::irdl::detail::StringAttributeStorage,
-                                    TypeConstraintAttrInterface::Trait> {
-public:
-  using Base::Base;
-
-  static EqDynTypeConstraintAttr get(MLIRContext &context, StringRef typeName);
-
-  FailureOr<std::unique_ptr<mlir::irdl::TypeConstraint>>
-  getTypeConstraint(OperationOp op, dyn::DynamicContext &ctx);
-
-  StringRef getValue();
-};
-
 /// Attribute for equality type constraint.
 class EqTypeConstraintAttr
     : public mlir::Attribute::AttrBase<EqTypeConstraintAttr, mlir::Attribute,
@@ -160,8 +143,8 @@ public:
 
   static EqTypeConstraintAttr get(MLIRContext &context, Type type);
 
-  FailureOr<std::unique_ptr<mlir::irdl::TypeConstraint>>
-  getTypeConstraint(OperationOp op, dyn::DynamicContext &ctx);
+  std::unique_ptr<mlir::irdl::TypeConstraint>
+  getTypeConstraint(dyn::DynamicContext &ctx);
 
   Type getValue();
 };

--- a/include/Dyn/Dialect/IRDL/IR/IRDLInterface.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLInterface.h
@@ -14,7 +14,6 @@
 #ifndef DYN_DIALECT_IRDL_IR_IRDLINTERFACE_H_
 #define DYN_DIALECT_IRDL_IR_IRDLINTERFACE_H_
 
-#include "Dyn/Dialect/IRDL/IR/IRDL.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include <memory>
 

--- a/include/Dyn/Dialect/IRDL/IR/IRDLInterface.td
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLInterface.td
@@ -24,8 +24,8 @@ def TypeConstraintAttrInterface : AttrInterface<"TypeConstraintAttrInterface"> {
   let methods = [
     InterfaceMethod<
       "Get the type constraint",
-      "mlir::FailureOr<std::unique_ptr<mlir::irdl::TypeConstraint>>", "getTypeConstraint",
-      (ins "mlir::irdl::OperationOp":$op, "mlir::dyn::DynamicContext &":$ctx)
+      "std::unique_ptr<mlir::irdl::TypeConstraint>", "getTypeConstraint",
+      (ins "mlir::dyn::DynamicContext &":$ctx)
     >
   ];
 }

--- a/include/Dyn/Dialect/IRDL/IRDLRegistration.h
+++ b/include/Dyn/Dialect/IRDL/IRDLRegistration.h
@@ -18,15 +18,20 @@
 
 namespace mlir {
 
-namespace dyn {
 // Forward declaration.
+namespace dyn {
 class DynamicContext;
+class DynamicDialect;
 } // namespace dyn
 
 namespace irdl {
 
-/// Register a dialect defined in IRDL in a MLIR context.
-LogicalResult registerDialect(DialectOp dialectOp, dyn::DynamicContext *ctx);
+/// Register a new dynamic type in a dynamic dialect.
+LogicalResult registerType(dyn::DynamicDialect *dialect, StringRef name);
+
+/// Register a new dynamic operation in a dynamic dialect.
+LogicalResult registerOperation(dyn::DynamicDialect *dialect, StringRef name,
+                                OpTypeDef opTypeDef);
 
 } // namespace irdl
 } // namespace mlir

--- a/include/Dyn/Dialect/IRDL/TypeConstraint.h
+++ b/include/Dyn/Dialect/IRDL/TypeConstraint.h
@@ -45,11 +45,6 @@ class EqTypeConstraint : public TypeConstraint {
 public:
   EqTypeConstraint(Type type) : type(type) {}
 
-  /// Get the type constraint given the type name.
-  /// The OperationOp should be the op having the type constraint.
-  static FailureOr<EqTypeConstraint> get(StringRef typeName, OperationOp op,
-                                         dyn::DynamicContext &ctx);
-
   /// Check that a type is satisfying the type constraint.
   /// The operation should be the operation having the type constraint.
   /// isOperand is used for the error message, and indicate if the constraint

--- a/include/Dyn/DynamicContext.h
+++ b/include/Dyn/DynamicContext.h
@@ -103,6 +103,12 @@ private:
 
   /// The MLIR context. It is used to register dialects, operations, types, ...
   MLIRContext *ctx;
+
+public:
+  /// This field is used during parsing, and may be needed to be moved somewhere
+  /// else. If this field is non-null, it points to the dialect that is
+  /// currently being parsed by MLIR.
+  DynamicDialect *currentlyParsedDialect = nullptr;
 };
 
 } // namespace dyn

--- a/include/Dyn/DynamicContext.h
+++ b/include/Dyn/DynamicContext.h
@@ -15,6 +15,7 @@
 
 #include "Dyn/DynamicType.h"
 #include "TypeIDAllocator.h"
+#include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
@@ -38,9 +39,13 @@ class DynamicOperation;
 
 /// Manages the creation and lifetime of dynamic MLIR objects such as dialects,
 /// operations, types, and traits
-class DynamicContext {
+/// The dynamic context is a dialect so we can get the instance through
+/// `MLIRContext::getLoadedDialect`. This is a bit of a hack though.
+class DynamicContext : public mlir::Dialect {
 public:
-  DynamicContext(MLIRContext *ctx);
+  static StringRef getDialectNamespace() { return "DynamicContext"; }
+
+  explicit DynamicContext(mlir::MLIRContext *ctx);
 
   TypeIDAllocator &getTypeIDAllocator() { return typeIDAllocator; }
 

--- a/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
@@ -66,28 +66,6 @@ struct TypeAttributeStorage : public AttributeStorage {
 } // namespace mlir
 
 //===----------------------------------------------------------------------===//
-// IRDL Equality type constraint attribute with dynamic types
-//===----------------------------------------------------------------------===//
-
-EqDynTypeConstraintAttr EqDynTypeConstraintAttr::get(MLIRContext &context,
-                                                     StringRef typeName) {
-  return Base::get(&context, typeName);
-}
-
-FailureOr<std::unique_ptr<TypeConstraint>>
-EqDynTypeConstraintAttr::getTypeConstraint(OperationOp op,
-                                           DynamicContext &ctx) {
-  auto constraint = EqTypeConstraint::get(getValue(), op, ctx);
-  if (failed(constraint))
-    return failure();
-
-  return static_cast<std::unique_ptr<TypeConstraint>>(
-      std::make_unique<EqTypeConstraint>(*constraint));
-}
-
-StringRef EqDynTypeConstraintAttr::getValue() { return getImpl()->value; }
-
-//===----------------------------------------------------------------------===//
 // IRDL Equality type constraint attribute
 //===----------------------------------------------------------------------===//
 
@@ -96,10 +74,9 @@ EqTypeConstraintAttr EqTypeConstraintAttr::get(MLIRContext &context,
   return Base::get(&context, type);
 }
 
-FailureOr<std::unique_ptr<TypeConstraint>>
-EqTypeConstraintAttr::getTypeConstraint(OperationOp op, DynamicContext &ctx) {
-  return static_cast<std::unique_ptr<TypeConstraint>>(
-      std::make_unique<EqTypeConstraint>(getValue()));
+std::unique_ptr<TypeConstraint>
+EqTypeConstraintAttr::getTypeConstraint(DynamicContext &ctx) {
+  return std::make_unique<EqTypeConstraint>(getValue());
 }
 
 Type EqTypeConstraintAttr::getValue() { return getImpl()->value; }

--- a/lib/Dyn/Dialect/IRDL/TypeConstraint.cpp
+++ b/lib/Dyn/Dialect/IRDL/TypeConstraint.cpp
@@ -20,42 +20,10 @@ using namespace mlir;
 using namespace dyn;
 using namespace irdl;
 
-FailureOr<EqTypeConstraint>
-EqTypeConstraint::get(StringRef typeName, OperationOp op, DynamicContext &ctx) {
-  auto dialectEnd = typeName.find('.');
-
-  StringRef dialectName, typeSubname;
-  if (dialectEnd == std::string::npos) {
-    dialectName = op.getDialectOp().name();
-    typeSubname = typeName;
-  } else {
-    dialectName = StringRef(typeName).substr(0, dialectEnd);
-    typeSubname = StringRef(typeName).substr(dialectEnd + 1);
-  }
-
-  /// Get the dialect owning the type.
-  auto dialectRes = ctx.lookupDialect(dialectName);
-  if (failed(dialectRes))
-    return LogicalResult(
-        op->emitOpError("dialect ").append(dialectName, " is not registered."));
-  auto *dialect = *dialectRes;
-
-  /// Get the type from the dialect.
-  auto dynTypeRes = dialect->lookupType(typeSubname);
-  if (failed(dynTypeRes))
-    return LogicalResult(op->emitOpError("type ").append(
-        typeSubname, " is not registered in the dialect ", dialectName, "."));
-  auto *dynType = *dynTypeRes;
-
-  auto type = DynamicType::get(ctx.getMLIRCtx(), dynType);
-
-  return EqTypeConstraint(type);
-}
-
 LogicalResult EqTypeConstraint::verifyType(Operation *op, Type argType,
                                            bool isOperand, unsigned pos,
                                            dyn::DynamicContext &ctx) {
-  if (type == this->type)
+  if (type == argType)
     return success();
 
   auto argCategory = isOperand ? "operand" : "result";

--- a/lib/Dyn/DynamicContext.cpp
+++ b/lib/Dyn/DynamicContext.cpp
@@ -22,7 +22,9 @@
 using namespace mlir;
 using namespace dyn;
 
-DynamicContext::DynamicContext(MLIRContext *ctx) : ctx{ctx} {}
+DynamicContext::DynamicContext(MLIRContext *ctx)
+    : Dialect(getDialectNamespace(), ctx, TypeID::get<DynamicContext>()),
+      ctx{ctx} {}
 
 mlir::FailureOr<DynamicDialect *>
 DynamicContext::createAndRegisterDialect(llvm::StringRef name) {

--- a/test/Dyn/cmath.irdl
+++ b/test/Dyn/cmath.irdl
@@ -5,11 +5,11 @@ module {
     irdl.dialect cmath {
         // CHECK: irdl.type complex
         irdl.type complex
-        // CHECK: irdl.operation make_complex(re: f32, im: f32) -> (res: cmath.complex)
-        irdl.operation make_complex(re : f32, im: f32) -> (res: cmath.complex)
-        irdl.operation mul(lhs: cmath.complex, rhs: cmath.complex) -> (res: cmath.complex)
-        irdl.operation norm(c: cmath.complex) -> (res: f32)
-        irdl.operation get_real(c: cmath.complex) -> (res: f32)
-        irdl.operation get_imaginary(c: cmath.complex) -> (res: f32)
+        // CHECK: irdl.operation make_complex(re: f32, im: f32) -> (res: !cmath.complex)
+        irdl.operation make_complex(re : f32, im: f32) -> (res: !cmath.complex)
+        irdl.operation mul(lhs: !cmath.complex, rhs: !cmath.complex) -> (res: !cmath.complex)
+        irdl.operation norm(c: !cmath.complex) -> (res: f32)
+        irdl.operation get_real(c: !cmath.complex) -> (res: f32)
+        irdl.operation get_imaginary(c: !cmath.complex) -> (res: f32)
     }
 }


### PR DESCRIPTION
Depends on #18

By registering dialects while parsing, we can use IRDL types as arguments of
C++-defined types. It also simplify overall the way parsing works, since we
can directly parse IRDL types, instead of storing a string, and fetching
them later.

This solution is a bit of a hack though.
