### PR TITLE
Add alias types

### DIFF
--- a/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLOps.td
@@ -120,6 +120,43 @@ def IRDL_TypeOp : IRDL_Op<"type", [HasParent<"DialectOp">]> {
 }
 
 //===----------------------------------------------------------------------===//
+// IRDL Alias definition
+//===----------------------------------------------------------------------===//
+
+def IRDL_TypeAliasOp : IRDL_Op<"alias", [HasParent<"DialectOp">]> {
+  let summary = "Define a new type alias";
+  let description = [{
+    `irdl.alias` defines new type aliases belonging to the previously defined
+    dialect using `irdl.dialect`.
+
+    Types defined by `irdl.aliases` are singleton types.
+
+    Example:
+
+    ```mlir
+    irdl.dialect cmath {
+      irdl.alias complex = tuple<f32, f32>
+      irdl.operation create_complex(real: f32, imaginary: f32) -> !cmath.complex
+    }
+    ```
+
+    The above program defines a type alias `complex` inside the dialect `cmath`.
+    In the `create_complex` operation, `complex` is replaced by
+    `tuple<f32, f32>`.
+  }];
+
+  let arguments = (ins StrAttr:$name, TypeAttr:$type);
+  let printer = [{ ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+
+  let extraClassDeclaration = [{
+    /// Get the parent dialect operation.
+    DialectOp getDialectOp() { return cast<DialectOp>(getOperation()->getParentOp()); };
+  }];
+}
+
+
+//===----------------------------------------------------------------------===//
 // IRDL Attribute definition
 //===----------------------------------------------------------------------===//
 

--- a/include/Dyn/Dialect/IRDL/IRDLRegistration.h
+++ b/include/Dyn/Dialect/IRDL/IRDLRegistration.h
@@ -29,6 +29,10 @@ namespace irdl {
 /// Register a new dynamic type in a dynamic dialect.
 LogicalResult registerType(dyn::DynamicDialect *dialect, StringRef name);
 
+/// Register a new type alias in a dynamic dialect.
+LogicalResult registerTypeAlias(dyn::DynamicDialect *dialect, StringRef name,
+                                Type type);
+
 /// Register a new dynamic operation in a dynamic dialect.
 LogicalResult registerOperation(dyn::DynamicDialect *dialect, StringRef name,
                                 OpTypeDef opTypeDef);

--- a/include/Dyn/DynamicDialect.h
+++ b/include/Dyn/DynamicDialect.h
@@ -54,6 +54,10 @@ public:
   /// The name of the type should not begin with the name of the dialect.
   FailureOr<DynamicTypeDefinition *> createAndAddType(StringRef name);
 
+  /// Create and add a new type alias to the dialect.
+  /// The name of the type alias should not begin with the name of the dialect.
+  LogicalResult createAndAddTypeAlias(StringRef name, Type type);
+
   mlir::Type parseType(mlir::DialectAsmParser &parser) const override;
 
   void printType(mlir::Type type,
@@ -74,6 +78,15 @@ public:
     if (it == typeIDToDynTypes.end())
       return failure();
     return &*it->second;
+  }
+
+  /// The pointer is guaranteed to be non-null.
+  /// The name format should be 'alias' and not 'dialect.alias'.
+  FailureOr<Type> lookupTypeAlias(StringRef name) const {
+    auto it = typeAliases.find(name);
+    if (it == typeAliases.end())
+      return failure();
+    return Type(it->second);
   }
 
   /// The pointer is guaranteed to be non-null.
@@ -113,6 +126,10 @@ private:
   /// This structure allows to get in O(1) a dynamic type given its typeID.
   /// This is useful for accessing the verifier efficiently for instance.
   llvm::DenseMap<TypeID, DynamicOperation *> typeIDToDynOps{};
+
+  /// Type aliases registered in this dialect.
+  /// Their name is stored with the format `alias` and not `dialect.alias`.
+  llvm::StringMap<Type> typeAliases{};
 
   /// Context in which the dialect is registered.
   DynamicContext *ctx;

--- a/include/Dyn/DynamicDialect.h
+++ b/include/Dyn/DynamicDialect.h
@@ -80,7 +80,6 @@ public:
     return &*it->second;
   }
 
-  /// The pointer is guaranteed to be non-null.
   /// The name format should be 'alias' and not 'dialect.alias'.
   FailureOr<Type> lookupTypeAlias(StringRef name) const {
     auto it = typeAliases.find(name);

--- a/include/Dyn/DynamicDialect.h
+++ b/include/Dyn/DynamicDialect.h
@@ -88,6 +88,15 @@ public:
     return Type(it->second);
   }
 
+  /// The name format should be 'type' and not 'dialect.type'
+  FailureOr<Type> lookupTypeOrTypeAlias(StringRef name) const {
+    auto dynType = lookupType(name);
+    if (succeeded(dynType))
+      return DynamicType::get(getContext(), *dynType);
+
+    return lookupTypeAlias(name);
+  }
+
   /// The pointer is guaranteed to be non-null.
   /// The name format should be 'dialect.operation'.
   FailureOr<DynamicOperation *> lookupOp(StringRef name) const {

--- a/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
+++ b/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
@@ -29,6 +29,11 @@ namespace irdl {
 LogicalResult registerType(dyn::DynamicDialect *dialect, StringRef name) {
   return dialect->createAndAddType(name);
 }
+
+LogicalResult registerTypeAlias(dyn::DynamicDialect *dialect, StringRef name,
+                                Type type) {
+  return dialect->createAndAddTypeAlias(name, type);
+}
 } // namespace irdl
 } // namespace mlir
 

--- a/test/Dyn/cmath.irdl
+++ b/test/Dyn/cmath.irdl
@@ -3,13 +3,15 @@
 module {
     // CHECK-LABEL: irdl.dialect cmath {
     irdl.dialect cmath {
-        // CHECK: irdl.type complex
-        irdl.type complex
-        // CHECK: irdl.operation make_complex(re: f32, im: f32) -> (res: !cmath.complex)
-        irdl.operation make_complex(re : f32, im: f32) -> (res: !cmath.complex)
-        irdl.operation mul(lhs: !cmath.complex, rhs: !cmath.complex) -> (res: !cmath.complex)
-        irdl.operation norm(c: !cmath.complex) -> (res: f32)
-        irdl.operation get_real(c: !cmath.complex) -> (res: f32)
-        irdl.operation get_imaginary(c: !cmath.complex) -> (res: f32)
+        // CHECK: irdl.type real 
+        irdl.type real
+        // CHECK: irdl.alias ccomplex = tuple<!cmath.real, !cmath.real>
+        irdl.alias ccomplex = tuple<!cmath.real, !cmath.real>
+        // CHECK: irdl.operation make_complex(re: !cmath.real, im: !cmath.real) -> (res: tuple<!cmath.real, !cmath.real>)
+        irdl.operation make_complex(re : real, im: real) -> (res: ccomplex)
+        irdl.operation mul(lhs: ccomplex, rhs: ccomplex) -> (res: ccomplex)
+        irdl.operation norm(c: ccomplex) -> (res: real)
+        irdl.operation get_real(c: ccomplex) -> (res: real)
+        irdl.operation get_imaginary(c: ccomplex) -> (res: real)
     }
 }

--- a/test/Dyn/test-complex.mlir
+++ b/test/Dyn/test-complex.mlir
@@ -1,18 +1,18 @@
 // RUN: dyn-opt %s --irdl-file=%S/cmath.irdl | dyn-opt --irdl-file=%S/cmath.irdl | FileCheck %s
 
 module {
-    // CHECK-LABEL: func @bar(%{{.*}}: f32, %{{.*}}: f32) {
-    func @bar(%re: f32, %im: f32) {
-        // CHECK: %{{.*}} = "cmath.make_complex"(%{{.*}}, %{{.*}}) : (f32, f32) -> !cmath.complex
-        %c = "cmath.make_complex"(%re, %im) : (f32, f32) -> !cmath.complex
-        // CHECK: %{{.*}} = "cmath.mul"(%{{.*}}, %{{.*}}) : (!cmath.complex, !cmath.complex) -> !cmath.complex
-        %c2 = "cmath.mul"(%c, %c) : (!cmath.complex, !cmath.complex) -> !cmath.complex
-        // CHECK: %{{.*}} = "cmath.norm"(%{{.*}}) : (!cmath.complex) -> f32
-        %resnorm = "cmath.norm"(%c2) : (!cmath.complex) -> f32
-        // CHECK: %{{.*}} = "cmath.get_real"(%{{.*}}) : (!cmath.complex) -> f32
-        %res_real = "cmath.get_real"(%c2) : (!cmath.complex) -> f32
-        // CHECK: %{{.*}} = "cmath.get_imaginary"(%{{.*}}) : (!cmath.complex) -> f32
-        %res_im = "cmath.get_imaginary"(%c2) : (!cmath.complex) -> f32
+    // CHECK-LABEL: func @bar(%{{.*}}: !cmath.real, %{{.*}}: !cmath.real) {
+    func @bar(%re: !cmath.real, %im: !cmath.real) {
+        // CHECK: %{{.*}} = "cmath.make_complex"(%{{.*}}, %{{.*}}) : (!cmath.real, !cmath.real) -> tuple<!cmath.real, !cmath.real>
+        %c = "cmath.make_complex"(%re, %im) : (!cmath.real, !cmath.real) -> !cmath.ccomplex
+        // CHECK: %{{.*}} = "cmath.mul"(%{{.*}}, %{{.*}}) : (tuple<!cmath.real, !cmath.real>, tuple<!cmath.real, !cmath.real>) -> tuple<!cmath.real, !cmath.real>
+        %c2 = "cmath.mul"(%c, %c) : (!cmath.ccomplex, !cmath.ccomplex) -> !cmath.ccomplex
+        // CHECK: %{{.*}} = "cmath.norm"(%{{.*}}) : (tuple<!cmath.real, !cmath.real>) -> !cmath.real
+        %resnorm = "cmath.norm"(%c2) : (!cmath.ccomplex) -> !cmath.real
+        // CHECK: %{{.*}} = "cmath.get_real"(%{{.*}}) : (tuple<!cmath.real, !cmath.real>) -> !cmath.real
+        %res_real = "cmath.get_real"(%c2) : (!cmath.ccomplex) -> !cmath.real
+        // CHECK: %{{.*}} = "cmath.get_imaginary"(%{{.*}}) : (tuple<!cmath.real, !cmath.real>) -> !cmath.real
+        %res_im = "cmath.get_imaginary"(%c2) : (!cmath.ccomplex) -> !cmath.real
         return
     }
 }


### PR DESCRIPTION
This adds type aliases in IRDL.
declaring a type alias `irdl.alias alias = type` will basically replace all `!dialect.alias` by `type` during parsing. They can't however be used during printing.