### PR TITLE
Anyof type constraint

### DIFF
--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -34,6 +34,7 @@ namespace detail {
 // Forward declaration.
 struct StringAttributeStorage;
 struct TypeAttributeStorage;
+struct TypeArrayAttrStorage;
 } // namespace detail
 
 /// Definition of an argument. An argument is either an operand or a result.
@@ -147,6 +148,26 @@ public:
   getTypeConstraint(dyn::DynamicContext &ctx);
 
   Type getValue();
+};
+
+//===----------------------------------------------------------------------===//
+// IRDL type set membership constraint attribute
+//===----------------------------------------------------------------------===//
+
+/// Attribute for equality type constraint.
+class AnyOfTypeConstraintAttr
+    : public mlir::Attribute::AttrBase<AnyOfTypeConstraintAttr, mlir::Attribute,
+                                       mlir::irdl::detail::TypeArrayAttrStorage,
+                                       TypeConstraintAttrInterface::Trait> {
+public:
+  using Base::Base;
+
+  static AnyOfTypeConstraintAttr get(MLIRContext &context, Type type);
+
+  std::unique_ptr<mlir::irdl::TypeConstraint>
+  getTypeConstraint(dyn::DynamicContext &ctx);
+
+  ArrayRef<Type> getValue();
 };
 
 } // namespace irdl

--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -151,10 +151,10 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-// IRDL type set membership constraint attribute
+// IRDL AnyOf type constraint attribute
 //===----------------------------------------------------------------------===//
 
-/// Attribute for equality type constraint.
+/// Attribute for the AnyOf type constraint.
 class AnyOfTypeConstraintAttr
     : public mlir::Attribute::AttrBase<AnyOfTypeConstraintAttr, mlir::Attribute,
                                        mlir::irdl::detail::TypeArrayAttrStorage,

--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -162,7 +162,7 @@ class AnyOfTypeConstraintAttr
 public:
   using Base::Base;
 
-  static AnyOfTypeConstraintAttr get(MLIRContext &context, Type type);
+  static AnyOfTypeConstraintAttr get(MLIRContext &context, ArrayRef<Type> type);
 
   std::unique_ptr<mlir::irdl::TypeConstraint>
   getTypeConstraint(dyn::DynamicContext &ctx);

--- a/include/Dyn/Dialect/IRDL/TypeConstraint.h
+++ b/include/Dyn/Dialect/IRDL/TypeConstraint.h
@@ -33,6 +33,11 @@ class OperationOp;
 /// A generic type constraint.
 class TypeConstraint {
 public:
+  /// Check that a type is satisfying the type constraint.
+  /// The operation should be the operation having the type constraint.
+  /// isOperand is used for the error message, and indicate if the constraint
+  /// is on an operand or a resuls, and pos is the position of the
+  /// operand/result.
   virtual LogicalResult verifyType(Operation *op, Type type, bool isOperand,
                                    unsigned pos, dyn::DynamicContext &ctx) = 0;
 };
@@ -45,16 +50,29 @@ class EqTypeConstraint : public TypeConstraint {
 public:
   EqTypeConstraint(Type type) : type(type) {}
 
-  /// Check that a type is satisfying the type constraint.
-  /// The operation should be the operation having the type constraint.
-  /// isOperand is used for the error message, and indicate if the constraint
-  /// is on an operand or a resuls, and pos is the position of the
-  /// operand/result.
   virtual LogicalResult verifyType(Operation *op, Type argType, bool isOperand,
                                    unsigned pos,
                                    dyn::DynamicContext &ctx) override;
 
   Type type;
+};
+
+//===----------------------------------------------------------------------===//
+// AnyOf type constraint
+//===----------------------------------------------------------------------===//
+
+/// AnyOf type constraint.
+/// A type satisfies this constraint if it is included in a set of types.
+class AnyOfTypeConstraint : public TypeConstraint {
+public:
+  AnyOfTypeConstraint(llvm::ArrayRef<Type> types)
+      : types(types.begin(), types.end()) {}
+
+  virtual LogicalResult verifyType(Operation *op, Type argType, bool isOperand,
+                                   unsigned pos,
+                                   dyn::DynamicContext &ctx) override;
+
+  llvm::SmallVector<Type, 4> types;
 };
 
 } // namespace irdl

--- a/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
@@ -29,7 +29,7 @@ void IRDLDialect::initialize() {
 #define GET_OP_LIST
 #include "Dyn/Dialect/IRDL/IR/IRDLOps.cpp.inc"
       >();
-  addAttributes<OpTypeDefAttr, EqTypeConstraintAttr>();
+  addAttributes<OpTypeDefAttr, EqTypeConstraintAttr, AnyOfTypeConstraintAttr>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
@@ -109,7 +109,7 @@ struct TypeArrayAttrStorage : public AttributeStorage {
 } // namespace mlir
 
 AnyOfTypeConstraintAttr AnyOfTypeConstraintAttr::get(MLIRContext &context,
-                                                     Type type) {
+                                                     ArrayRef<Type> type) {
   return Base::get(&context, type);
 }
 

--- a/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
@@ -81,6 +81,10 @@ EqTypeConstraintAttr::getTypeConstraint(DynamicContext &ctx) {
 
 Type EqTypeConstraintAttr::getValue() { return getImpl()->value; }
 
+//===----------------------------------------------------------------------===//
+// IRDL AnyOf type constraint attribute
+//===----------------------------------------------------------------------===//
+
 namespace mlir {
 namespace irdl {
 namespace detail {

--- a/lib/Dyn/Dialect/IRDL/TypeConstraint.cpp
+++ b/lib/Dyn/Dialect/IRDL/TypeConstraint.cpp
@@ -32,3 +32,21 @@ LogicalResult EqTypeConstraint::verifyType(Operation *op, Type argType,
                                      " must be of type '", type, "', but got ",
                                      argType);
 }
+
+LogicalResult AnyOfTypeConstraint::verifyType(Operation *op, Type argType,
+                                              bool isOperand, unsigned pos,
+                                              dyn::DynamicContext &ctx) {
+  if (std::find(types.begin(), types.end(), argType) != types.end())
+    return success();
+
+  auto argCategory = isOperand ? "operand" : "result";
+
+  auto diagnostic = op->emitOpError("#").append(
+      pos, " ", argCategory, " is of type ", argType,
+      " but is expected to be one of the following types: [");
+
+  for (size_t i = 0; i + 1 < types.size(); i++) {
+    diagnostic.append(types[i], ", ");
+  }
+  return diagnostic.append(types.back(), "]");
+}

--- a/test/Dyn/test-type-constraints.irdl
+++ b/test/Dyn/test-type-constraints.irdl
@@ -1,0 +1,24 @@
+// RUN: dyn-opt %s | dyn-opt | FileCheck %s
+
+module {
+    // CHECK-LABEL: irdl.dialect testd {
+    irdl.dialect testd {
+        // CHECK: irdl.type testt
+        irdl.type testt
+
+        // CHECK: irdl.operation eq(c: !testd.testt) -> ()
+        irdl.operation eq(c: !testd.testt) -> ()
+        // CHECK: irdl.operation anyof(c: irdl.AnyOf<!testd.testt, i32>) -> ()
+        irdl.operation anyof(c: irdl.AnyOf<!testd.testt, i32>) -> ()
+    }
+
+    func @test(%a: !testd.testt, %b: i32) {
+        // CHECK: "testd.eq"(%{{.*}}) : (!testd.testt) -> ()
+        "testd.eq"(%a) : (!testd.testt) -> ()
+        // CHECK: "testd.anyof"(%{{.*}}) : (!testd.testt) -> ()
+        "testd.anyof"(%a) : (!testd.testt) -> ()
+        // CHECK: "testd.anyof"(%{{.*}}) : (i32) -> ()
+        "testd.anyof"(%b) : (i32) -> ()
+        return
+    }
+}


### PR DESCRIPTION
Depends on #20

Add the AnyOf type constraint.
`irdl.AnyOf<type1, type2, ...>` is satisfied by a type if it is equal to one of the "type1, type2, ..."