### PR TITLE
Add traits to irdl

### DIFF
--- a/dyn-opt/dyn-opt.cpp
+++ b/dyn-opt/dyn-opt.cpp
@@ -34,6 +34,10 @@ int main(int argc, char **argv) {
   MLIRContext ctx;
   auto dynCtx = ctx.getOrLoadDialect<DynamicContext>();
 
+  if (failed(dynCtx->createAndRegisterOpTrait<OpTrait::SameTypeOperands>(
+          "SameTypeOperands")))
+    llvm::errs() << "Failed to register trait";
+
   // Register the standard dialect and the IRDL dialect in the MLIR context
   DialectRegistry registry;
   registry.insert<StandardOpsDialect, irdl::IRDLDialect>();

--- a/include/Dyn/DynamicDialect.h
+++ b/include/Dyn/DynamicDialect.h
@@ -15,6 +15,7 @@
 
 #include "Dyn/DynamicObject.h"
 #include "Dyn/DynamicOperation.h"
+#include "Dyn/DynamicTrait.h"
 #include "Dyn/DynamicType.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OperationSupport.h"
@@ -45,10 +46,12 @@ public:
   mlir::StringRef getName() const { return name; }
 
   /// Create and register a new operation to the dialect.
-  /// The name of the operation should not begin with the name of the dialect.
-  FailureOr<DynamicOperation *> createAndAddOperation(
-      llvm::StringRef name,
-      std::vector<std::function<LogicalResult(Operation *)>> verifiers = {});
+  /// The name of the operation should not begin with the name of the
+  /// dialect.
+  FailureOr<DynamicOperation *>
+  createAndAddOperation(llvm::StringRef name,
+                        std::vector<DynamicOperation::VerifierFn> verifiers,
+                        std::vector<DynamicOpTrait *> traits);
 
   /// Create and add a new type to the dialect.
   /// The name of the type should not begin with the name of the dialect.

--- a/include/Dyn/DynamicOperation.h
+++ b/include/Dyn/DynamicOperation.h
@@ -14,6 +14,7 @@
 #define DYN_DYNAMICOPERATION_H
 
 #include "Dyn/DynamicObject.h"
+#include "Dyn/DynamicTrait.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include <mlir/IR/OpDefinition.h>
@@ -28,13 +29,14 @@ class DynamicDialect;
 class DynamicOperation : public mlir::Op<DynamicOperation>,
                          public DynamicObject {
 public:
+  using VerifierFn = std::function<mlir::LogicalResult(mlir::Operation *op)>;
+
   /// Create a new dynamic operation given the operation name and the defining
   /// dialect.
   /// The operation name should be `operation` and not `dialect.operation`.
-  DynamicOperation(
-      mlir::StringRef name, DynamicDialect *dialect,
-      std::vector<std::function<mlir::LogicalResult(mlir::Operation *op)>>
-          verifiers = {});
+  DynamicOperation(mlir::StringRef name, DynamicDialect *dialect,
+                   std::vector<VerifierFn> verifiers,
+                   std::vector<DynamicOpTrait *> traits);
 
   /// Get the operation name.
   /// The name should have the format `dialect.name`.
@@ -60,7 +62,7 @@ public:
   }
 
   /// Check if the operation has a specific trait given the trait TypeID.
-  static bool hasTrait(TypeID traitId) { return false; }
+  bool hasTrait(TypeID traitId);
 
 private:
   /// Full name of the operation: `dialect.operation`.
@@ -72,6 +74,9 @@ private:
   /// Custom verifiers for the operation.
   std::vector<std::function<mlir::LogicalResult(mlir::Operation *op)>>
       verifiers;
+
+  /// Operation traits TypeID.
+  std::vector<TypeID> traitsId;
 };
 
 } // namespace dyn

--- a/include/Dyn/DynamicTrait.h
+++ b/include/Dyn/DynamicTrait.h
@@ -1,0 +1,57 @@
+//===- DynamicTrait.h - Dynamic trait ---------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Allow the use of traits in dynamic operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DYNAMICTRAIT_H
+#define DYN_DYNAMICTRAIT_H
+
+#include "Dyn/DynamicObject.h"
+#include "mlir/IR/Operation.h"
+
+namespace mlir {
+namespace dyn {
+
+using OpTraitVerifierFn = std::function<LogicalResult(Operation *op)>;
+
+/// Trait that can be defined dynamically.
+class DynamicOpTrait : public DynamicObject {
+
+private:
+  DynamicOpTrait(DynamicContext *ctx, StringRef name,
+                 OpTraitVerifierFn verifier, TypeID id)
+      : DynamicObject(ctx, id), name{name}, verifier(std::move(verifier)) {}
+
+public:
+  DynamicOpTrait(DynamicContext *ctx, StringRef name,
+                 OpTraitVerifierFn verifier)
+      : DynamicObject(ctx), name{name}, verifier(std::move(verifier)) {}
+
+  template <template <typename ConcreteT> class TraitTy>
+  static std::unique_ptr<DynamicOpTrait> get(DynamicContext *ctx,
+                                             StringRef name) {
+    return std::unique_ptr<DynamicOpTrait>(new DynamicOpTrait(
+        ctx, name, TraitTy<Operation>::verifyTrait, TypeID::get<TraitTy>()));
+  }
+
+  /// Check that the operation satisfies the trait.
+  LogicalResult verifyTrait(Operation *op) { return verifier(op); }
+
+  const std::string name;
+
+private:
+  /// Lambda used for checking that the operation satisfy the trait.
+  OpTraitVerifierFn verifier;
+};
+
+} // namespace dyn
+} // namespace mlir
+
+#endif // DYN_DYNAMICTRAIT_H

--- a/lib/Dyn/CAPI/IR.cpp
+++ b/lib/Dyn/CAPI/IR.cpp
@@ -35,7 +35,7 @@ void mlirDynamicDialectDestroy(MlirDynamicDialect dialect) {
 MlirDynamicOperation mlirDynamicOperationCreate(MlirStringRef name,
                                                 MlirDynamicDialect dialect) {
   mlir::dyn::DynamicOperation *op =
-      new DynamicOperation(unwrap(name), unwrap(dialect));
+      new DynamicOperation(unwrap(name), unwrap(dialect), {}, {});
   return wrap(op);
 }
 

--- a/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
+++ b/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
@@ -95,6 +95,7 @@ LogicalResult registerOperation(dyn::DynamicDialect *dialect, StringRef name,
   OpTypeConstraints constraints;
   auto *ctx = dialect->getDynamicContext();
 
+  // Add the operand constraints to the type constraints.
   for (auto &def : opTypeDef.operandDef) {
     auto name = def.first;
     auto constraint =
@@ -102,6 +103,7 @@ LogicalResult registerOperation(dyn::DynamicDialect *dialect, StringRef name,
     constraints.first.emplace_back(name, std::move(constraint));
   }
 
+  // Add the result constraints to the type constraints.
   for (auto &def : opTypeDef.resultDef) {
     auto name = def.first;
     auto constraint =
@@ -109,13 +111,15 @@ LogicalResult registerOperation(dyn::DynamicDialect *dialect, StringRef name,
     constraints.second.emplace_back(name, std::move(constraint));
   }
 
+  // Create the type verifier.
   auto typeVerifier =
       [constraints{std::make_shared<OpTypeConstraints>(std::move(constraints))},
        ctx](Operation *op) {
         return verifyOpTypeConstraints(op, *constraints, *ctx);
       };
 
-  return dialect->createAndAddOperation(name, {std::move(typeVerifier)});
+  return dialect->createAndAddOperation(name, {std::move(typeVerifier)},
+                                        opTypeDef.traitDefs);
 }
 } // namespace irdl
 } // namespace mlir

--- a/lib/Dyn/DynamicContext.cpp
+++ b/lib/Dyn/DynamicContext.cpp
@@ -13,6 +13,7 @@
 #include "Dyn/DynamicContext.h"
 #include "Dyn/DynamicDialect.h"
 #include "Dyn/DynamicOperation.h"
+#include "Dyn/DynamicTrait.h"
 #include "Dyn/DynamicType.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/Support/LogicalResult.h"
@@ -57,4 +58,18 @@ DynamicContext::createAndRegisterDialect(llvm::StringRef name) {
   dialects.insert({name, dynDialect});
 
   return dynDialect;
+}
+
+mlir::FailureOr<DynamicOpTrait *>
+DynamicContext::registerOpTrait(llvm::StringRef name,
+                                std::unique_ptr<DynamicOpTrait> opTrait) {
+  auto opTraitPtr = opTrait.get();
+
+  auto inserted = opTraits.try_emplace(name, std::move(opTrait));
+  if (!inserted.second)
+    return failure();
+
+  typeIDToOpTraits.insert({opTraitPtr->getRuntimeTypeID(), opTraitPtr});
+
+  return inserted.first->second.get();
 }

--- a/test/Dyn/test-type-constraints.irdl
+++ b/test/Dyn/test-type-constraints.irdl
@@ -10,8 +10,12 @@ module {
         irdl.operation eq(c: !testd.testt) -> ()
         // CHECK: irdl.operation anyof(c: irdl.AnyOf<!testd.testt, i32>) -> ()
         irdl.operation anyof(c: irdl.AnyOf<!testd.testt, i32>) -> ()
+
         // CHECK: irdl.operation any(c: irdl.Any) -> ()
         irdl.operation any(c: irdl.Any) -> ()
+
+        // CHECK: irdl.operation any_with_trait(c: irdl.Any, d: irdl.Any) -> () traits [SameTypeOperands]
+        irdl.operation any_with_trait(c: irdl.Any, d: irdl.Any) -> () traits [SameTypeOperands]
     }
 
     func @test(%a: !testd.testt, %b: i32) {
@@ -28,6 +32,7 @@ module {
         // CHECK: "testd.any"(%{{.*}}) : (i32) -> ()
         "testd.any"(%b) : (i32) -> ()
 
+        "testd.any_with_trait"(%b, %b) : (i32, i32) -> ()
         return
     }
 }


### PR DESCRIPTION
Traits are registered in the context, and can then be parsed in the operation definition.
For now, only non-parametrized traits are implemented, and interfaces are not implemented.
It is also possible to define new custom traits, but not from irdl (though it wouldn't be a hard change).