### PR TITLE
Add interfaces to IRDL

### DIFF
--- a/dyn-opt/dyn-opt.cpp
+++ b/dyn-opt/dyn-opt.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dyn/Dialect/IRDL/IR/IRDL.h"
+#include "Dyn/Dialect/IRDL/IR/StandardOpInterface.h"
 #include "Dyn/DynamicContext.h"
 #include "Dyn/DynamicDialect.h"
 #include "MlirOptMain.h"
@@ -23,6 +24,7 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace mlir;
 using namespace dyn;
@@ -35,8 +37,16 @@ int main(int argc, char **argv) {
   auto dynCtx = ctx.getOrLoadDialect<DynamicContext>();
 
   if (failed(dynCtx->createAndRegisterOpTrait<OpTrait::SameTypeOperands>(
-          "SameTypeOperands")))
-    llvm::errs() << "Failed to register trait";
+          "SameTypeOperands"))) {
+    llvm::errs() << "Failed to register trait\n";
+    return 1;
+  }
+
+  if (failed(dynCtx->createAndRegisterOpInterface<
+             irdl::DynMemoryEffectOpInterface>("MemoryEffect"))) {
+    llvm::errs() << "Failed to register interface\n";
+    return 1;
+  }
 
   // Register the standard dialect and the IRDL dialect in the MLIR context
   DialectRegistry registry;

--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -39,6 +39,24 @@ struct TypeAttributeStorage;
 struct TypeArrayAttrStorage;
 } // namespace detail
 
+namespace detail {
+/// Attribute storage for string arrays.
+/// This should be moved somewhere else in MLIR.
+struct StringArrayAttrStorage : public AttributeStorage {
+  using KeyTy = ArrayRef<StringRef>;
+
+  StringArrayAttrStorage(ArrayRef<StringRef> values) : values(values) {}
+
+  /// Key equality function.
+  bool operator==(const KeyTy &key) const { return key == values; }
+
+  static StringArrayAttrStorage *construct(AttributeStorageAllocator &allocator,
+                                           KeyTy key);
+
+  ArrayRef<StringRef> values;
+};
+} // namespace detail
+
 /// Definition of an argument. An argument is either an operand or a result.
 /// It is represented by a name an a type constraint.
 using ArgDef = std::pair<StringRef, Attribute>;

--- a/include/Dyn/Dialect/IRDL/IR/IRDLInterface.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLInterface.h
@@ -15,6 +15,7 @@
 #define DYN_DIALECT_IRDL_IR_IRDLINTERFACE_H_
 
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/OpImplementation.h"
 #include <memory>
 
 // Forward declaration.
@@ -24,7 +25,8 @@ class TypeConstraint;
 }
 namespace dyn {
 class DynamicContext;
-}
+class DynamicOpInterfaceImpl;
+} // namespace dyn
 } // namespace mlir
 
 //===----------------------------------------------------------------------===//

--- a/include/Dyn/Dialect/IRDL/IR/IRDLInterface.td
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLInterface.td
@@ -30,4 +30,21 @@ def TypeConstraintAttrInterface : AttrInterface<"TypeConstraintAttrInterface"> {
   ];
 }
 
+def InterfaceImplAttrInterface : AttrInterface<"InterfaceImplAttrInterface"> {
+  let description = [{
+    Attribute representing the implementation of an interface.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      "Get the interface implementation",
+      "std::unique_ptr<mlir::dyn::DynamicOpInterfaceImpl>", "getInterfaceImpl"
+    >,
+    InterfaceMethod<
+      "Print the attribute",
+      "void", "print", (ins "mlir::OpAsmPrinter&":$p)
+    >
+  ];
+}
+
 #endif // DYN_DIALECT_IRDL_IR_IRDLATTRIBUTES

--- a/include/Dyn/Dialect/IRDL/IR/StandardOpInterface.h
+++ b/include/Dyn/Dialect/IRDL/IR/StandardOpInterface.h
@@ -1,0 +1,76 @@
+//===- StandardOpInterfaceAttrs.h - Std Interface Attributes ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the attributes used in the IRDL dialect to represent
+// standard interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DIALECT_IRDL_IR_STANDARDOPINTERFACEATTRS_H_
+#define DYN_DIALECT_IRDL_IR_STANDARDOPINTERFACEATTRS_H_
+
+#include "Dyn/Dialect/IRDL/IR/IRDLAttributes.h"
+#include "Dyn/Dialect/IRDL/IR/IRDLInterface.h"
+#include "Dyn/DynamicInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+namespace mlir {
+namespace irdl {
+
+/// Attribute used in IRDL to represent the implementation of a
+/// MemoryEffectInterface.
+class DynMemoryEffectOpInterfaceAttr
+    : public mlir::Attribute::AttrBase<
+          DynMemoryEffectOpInterfaceAttr, mlir::Attribute,
+          detail::StringArrayAttrStorage, InterfaceImplAttrInterface::Trait> {
+public:
+  // Using Attribute constructors.
+  using Base::Base;
+
+  static DynMemoryEffectOpInterfaceAttr get(MLIRContext &ctx,
+                                            ArrayRef<StringRef> effects) {
+    return Base::get(&ctx, effects);
+  }
+
+  std::unique_ptr<mlir::dyn::DynamicOpInterfaceImpl> getInterfaceImpl();
+
+  void print(mlir::OpAsmPrinter &p);
+  static ParseResult parse(mlir::OpAsmParser &p,
+                           DynMemoryEffectOpInterfaceAttr &attr);
+};
+
+/// Operation interface wrapper for MemoryEffectInterface.
+class DynMemoryEffectOpInterface : public dyn::DynamicOpInterface {
+public:
+  DynMemoryEffectOpInterface(dyn::DynamicContext *ctx)
+      : DynamicOpInterface(ctx, mlir::MemoryEffectOpInterface::getInterfaceID(),
+                           "MemoryEffect") {}
+
+  virtual void *getConcept() override;
+
+  virtual FailureOr<dyn::DynamicOpInterfaceImpl *>
+  getImpl(Operation *op) override;
+
+  virtual ParseResult parseImpl(OpAsmParser &p,
+                                InterfaceImplAttrInterface &interface) override;
+};
+
+/// Implementation of a MemoryEffectInterface.
+class DynMemoryEffectOpInterfaceImpl : public dyn::DynamicOpInterfaceImpl {
+public:
+  DynMemoryEffectOpInterfaceImpl(
+      dyn::DynamicContext *dynCtx,
+      std::vector<MemoryEffects::EffectInstance> effects);
+
+  const std::vector<MemoryEffects::EffectInstance> effects;
+};
+
+} // namespace irdl
+} // namespace mlir
+
+#endif //  DYN_DIALECT_IRDL_IR_STANDARDOPINTERFACEATTRS_H_

--- a/include/Dyn/DynamicDialect.h
+++ b/include/Dyn/DynamicDialect.h
@@ -31,6 +31,7 @@ namespace dyn {
 
 // Forward declaration.
 class DynamicContext;
+class DynamicOpTrait;
 
 /// Each instance of DynamicDialect correspond to a different dialect.
 class DynamicDialect : public DynamicObject, public mlir::Dialect {
@@ -48,10 +49,10 @@ public:
   /// Create and register a new operation to the dialect.
   /// The name of the operation should not begin with the name of the
   /// dialect.
-  FailureOr<DynamicOperation *>
-  createAndAddOperation(llvm::StringRef name,
-                        std::vector<DynamicOperation::VerifierFn> verifiers,
-                        std::vector<DynamicOpTrait *> traits);
+  FailureOr<DynamicOperation *> createAndAddOperation(
+      llvm::StringRef name, std::vector<DynamicOperation::VerifierFn> verifiers,
+      std::vector<DynamicOpTrait *> traits,
+      std::vector<std::unique_ptr<DynamicOpInterfaceImpl>> interfaces);
 
   /// Create and add a new type to the dialect.
   /// The name of the type should not begin with the name of the dialect.

--- a/include/Dyn/DynamicInterface.h
+++ b/include/Dyn/DynamicInterface.h
@@ -1,0 +1,86 @@
+//===- DynamicTrait.h - Dynamic trait ---------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Allow the use of interfaces in dynamic operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DYNAMICINTERFACE_H
+#define DYN_DYNAMICINTERFACE_H
+
+#include "Dyn/Dialect/IRDL/IR/IRDLInterface.h"
+#include "Dyn/DynamicObject.h"
+#include "mlir/IR/AttributeSupport.h"
+#include "mlir/IR/Operation.h"
+
+namespace mlir {
+namespace dyn {
+
+// Forward declaration.
+class DynamicOpInterfaceImpl;
+
+// In MLIR, interface implementations are stored in an InterfaceTy::Concept
+// inside the InterfaceMap stored by the AbstractOperation. The Concept is
+// simply a struct containing a pointer to each function an operation has to
+// implement.
+// In order to have implementations depending on runtime information, we store
+// the dynamic information inside class deriving DynamicOpInterfaceImpl. Then,
+// we store in the InterfaceMap a function pointer which upon execution will
+// retrieve the dynamic operation, and get the interface implementation.
+//
+// In order to use a c++-defined interface in dynamic operations, the user need
+// to derive the DynamicOpInterface and the DynamicOpInterfaceImpl.
+
+/// A dynamic operation interface.
+/// Each instance of this class represent a different operation interface.
+class DynamicOpInterface : public DynamicObject {
+public:
+  DynamicOpInterface(DynamicContext *ctx, StringRef name)
+      : DynamicObject(ctx), name{name} {}
+
+  /// Give a custom TypeID to the interface.
+  /// This should only be used when creating a wrapper around an already defined
+  /// interface.
+  DynamicOpInterface(DynamicContext *ctx, TypeID id, StringRef name)
+      : DynamicObject(ctx, id), name{name} {}
+
+  /// Entry for the interfaceMap. The object should be allocated with malloc,
+  /// and the ownership is given to the caller.
+  /// The returned object should contain the operation implementation of the
+  /// interface.
+  virtual void *getConcept() = 0;
+
+  /// Get the interface implementation of an operation.
+  /// The operation must be a dynamic operation.
+  virtual FailureOr<DynamicOpInterfaceImpl *> getImpl(Operation *op) = 0;
+
+  /// Parse a textual representation of the interface implementation.
+  virtual ParseResult parseImpl(OpAsmParser &p,
+                                InterfaceImplAttrInterface &interface) = 0;
+
+  const std::string name;
+};
+
+/// An implementation of a dynamic interface.
+/// This object should contain the information specific to the interface
+/// implementation of an operation.
+class DynamicOpInterfaceImpl {
+public:
+  DynamicOpInterfaceImpl(DynamicOpInterface *interface)
+      : interface{interface} {}
+
+  DynamicOpInterface *getInterface() { return interface; }
+
+private:
+  DynamicOpInterface *interface;
+};
+
+} // namespace dyn
+} // namespace mlir
+
+#endif // DYN_DYNAMICINTERFACE_H

--- a/include/Dyn/DynamicOperation.h
+++ b/include/Dyn/DynamicOperation.h
@@ -81,7 +81,7 @@ private:
   std::vector<std::function<mlir::LogicalResult(mlir::Operation *op)>>
       verifiers;
 
-  /// Operation traits TypeID.
+  // Operation traits TypeID.
   std::vector<TypeID> traitsId;
 
   /// Interfaces and their implementations.

--- a/include/Dyn/DynamicOperation.h
+++ b/include/Dyn/DynamicOperation.h
@@ -17,6 +17,7 @@
 #include "Dyn/DynamicTrait.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/STLExtras.h"
 #include <mlir/IR/OpDefinition.h>
 
 namespace mlir {
@@ -24,6 +25,8 @@ namespace dyn {
 
 // Forward declaration.
 class DynamicDialect;
+class DynamicOpInterfaceImpl;
+class DynamicOpInterface;
 
 /// Each instance of DynamicOperation correspond to a different operation.
 class DynamicOperation : public mlir::Op<DynamicOperation>,
@@ -34,9 +37,10 @@ public:
   /// Create a new dynamic operation given the operation name and the defining
   /// dialect.
   /// The operation name should be `operation` and not `dialect.operation`.
-  DynamicOperation(mlir::StringRef name, DynamicDialect *dialect,
-                   std::vector<VerifierFn> verifiers,
-                   std::vector<DynamicOpTrait *> traits);
+  DynamicOperation(
+      mlir::StringRef name, DynamicDialect *dialect,
+      std::vector<VerifierFn> verifiers, std::vector<DynamicOpTrait *> traits,
+      std::vector<std::unique_ptr<DynamicOpInterfaceImpl>> interfaces);
 
   /// Get the operation name.
   /// The name should have the format `dialect.name`.
@@ -64,6 +68,8 @@ public:
   /// Check if the operation has a specific trait given the trait TypeID.
   bool hasTrait(TypeID traitId);
 
+  DynamicOpInterfaceImpl *getInterfaceImpl(DynamicOpInterface *interface);
+
 private:
   /// Full name of the operation: `dialect.operation`.
   const std::string name;
@@ -77,6 +83,10 @@ private:
 
   /// Operation traits TypeID.
   std::vector<TypeID> traitsId;
+
+  /// Interfaces and their implementations.
+  std::vector<std::pair<TypeID, std::unique_ptr<DynamicOpInterfaceImpl>>>
+      interfaces;
 };
 
 } // namespace dyn

--- a/lib/Dyn/CAPI/IR.cpp
+++ b/lib/Dyn/CAPI/IR.cpp
@@ -35,7 +35,7 @@ void mlirDynamicDialectDestroy(MlirDynamicDialect dialect) {
 MlirDynamicOperation mlirDynamicOperationCreate(MlirStringRef name,
                                                 MlirDynamicDialect dialect) {
   mlir::dyn::DynamicOperation *op =
-      new DynamicOperation(unwrap(name), unwrap(dialect), {}, {});
+      new DynamicOperation(unwrap(name), unwrap(dialect), {}, {}, {});
   return wrap(op);
 }
 

--- a/lib/Dyn/Dialect/IRDL/CMakeLists.txt
+++ b/lib/Dyn/Dialect/IRDL/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_dialect_library(MLIRIRDL
         IR/IRDL.cpp
         IR/IRDLAttributes.cpp
-        IR/StandardOpInterfaceAttrs.cpp
+        IR/StandardOpInterface.cpp
         IRDLRegistration.cpp
         TypeConstraint.cpp
 

--- a/lib/Dyn/Dialect/IRDL/CMakeLists.txt
+++ b/lib/Dyn/Dialect/IRDL/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRIRDL
         IR/IRDL.cpp
         IR/IRDLAttributes.cpp
+        IR/StandardOpInterfaceAttrs.cpp
         IRDLRegistration.cpp
         TypeConstraint.cpp
 

--- a/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
@@ -8,6 +8,7 @@
 
 #include "Dyn/Dialect/IRDL/IR/IRDL.h"
 #include "Dyn/Dialect/IRDL/IR/IRDLAttributes.h"
+#include "Dyn/Dialect/IRDL/IR/StandardOpInterface.h"
 #include "Dyn/Dialect/IRDL/IRDLRegistration.h"
 #include "Dyn/Dialect/IRDL/TypeConstraint.h"
 #include "Dyn/DynamicContext.h"
@@ -30,7 +31,7 @@ void IRDLDialect::initialize() {
 #include "Dyn/Dialect/IRDL/IR/IRDLOps.cpp.inc"
       >();
   addAttributes<OpTypeDefAttr, EqTypeConstraintAttr, AnyOfTypeConstraintAttr,
-                AnyTypeConstraintAttr>();
+                AnyTypeConstraintAttr, DynMemoryEffectOpInterfaceAttr>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
@@ -21,6 +21,17 @@ namespace mlir {
 namespace irdl {
 namespace detail {
 
+StringArrayAttrStorage *
+StringArrayAttrStorage::construct(AttributeStorageAllocator &allocator,
+                                  KeyTy key) {
+  std::vector<StringRef> strings;
+  for (auto str : key)
+    strings.push_back(allocator.copyInto(str));
+
+  return new (allocator.allocate<StringArrayAttrStorage>())
+      StringArrayAttrStorage(allocator.copyInto(ArrayRef<StringRef>(strings)));
+}
+
 /// An attribute representing a string value.
 /// This implementation already exists in MLIR, but is not public.
 struct StringAttributeStorage : public AttributeStorage {

--- a/lib/Dyn/Dialect/IRDL/IR/StandardOpInterface.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/StandardOpInterface.cpp
@@ -1,0 +1,188 @@
+//===- StandardInterfaceAttrs.cpp - Std Interface Attributes ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the attributes used in the IRDL dialect to represent
+// standard interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dyn/Dialect/IRDL/IR/StandardOpInterface.h"
+#include "Dyn/Dialect/IRDL/IR/IRDLAttributes.h"
+#include "Dyn/Dialect/IRDL/IR/IRDLInterface.h"
+#include "Dyn/DynamicContext.h"
+#include "Dyn/DynamicDialect.h"
+#include "Dyn/DynamicInterface.h"
+#include "Dyn/DynamicOperation.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using mlir::OpAsmParser;
+
+using namespace mlir;
+using namespace irdl;
+
+namespace {
+
+/// Get the list of available effects, and their names.
+std::vector<std::pair<StringRef, MemoryEffects::EffectInstance>>
+availableEffects() {
+  return {std::make_pair("Allocate", MemoryEffects::Allocate::get()),
+          std::make_pair("Free", MemoryEffects::Free::get()),
+          std::make_pair("Read", MemoryEffects::Read::get()),
+          std::make_pair("Write", MemoryEffects::Write::get())};
+};
+
+/// Check if there exist an effect with the given name.
+bool isEffectName(StringRef name) {
+  return llvm::any_of(availableEffects(),
+                      [name](auto a) { return a.first == name; });
+}
+
+/// Get the effect associated with the name.
+MemoryEffects::EffectInstance getEffect(StringRef name) {
+  assert(isEffectName(name) && "getEffect called with an invalid name");
+  return llvm::find_if(availableEffects(),
+                       [name](auto a) { return a.first == name; })
+      ->second;
+}
+
+} // namespace
+
+std::unique_ptr<dyn::DynamicOpInterfaceImpl>
+DynMemoryEffectOpInterfaceAttr::getInterfaceImpl() {
+  auto effectNames = getImpl()->values;
+  std::vector<MemoryEffects::EffectInstance> effects;
+  for (auto name : effectNames) {
+    effects.push_back(getEffect(name));
+  }
+
+  auto dynCtx = getContext()->getLoadedDialect<dyn::DynamicContext>();
+
+  return std::make_unique<DynMemoryEffectOpInterfaceImpl>(dynCtx,
+                                                          std::move(effects));
+}
+
+namespace {
+/// Parse a memory effect name.
+/// Emit an error in case the name is not a memory effect name.
+ParseResult parseEffectName(mlir::OpAsmParser &p, StringRef &name) {
+  auto loc = p.getCurrentLocation();
+
+  if (p.parseKeyword(name))
+    return failure();
+
+  if (!isEffectName(name)) {
+    p.emitError(loc, "'").append(name, "' is not a valid memory effect name.");
+    return failure();
+  }
+
+  return success();
+}
+} // namespace
+
+void DynMemoryEffectOpInterfaceAttr::print(mlir::OpAsmPrinter &p) {
+  p << "MemoryEffect";
+  auto values = getImpl()->values;
+
+  p << "<";
+  llvm::interleaveComma(values, p);
+  p << ">";
+}
+
+ParseResult
+DynMemoryEffectOpInterfaceAttr::parse(mlir::OpAsmParser &p,
+                                      DynMemoryEffectOpInterfaceAttr &attr) {
+  p.parseLess();
+
+  std::vector<StringRef> effects;
+
+  // empty
+  if (!p.parseOptionalGreater()) {
+    attr = DynMemoryEffectOpInterfaceAttr::get(*p.getBuilder().getContext(),
+                                               effects);
+    return success();
+  }
+
+  StringRef name;
+  if (parseEffectName(p, name))
+    return failure();
+
+  while (p.parseOptionalGreater()) {
+    StringRef name;
+    if (p.parseComma() || parseEffectName(p, name))
+      return failure();
+    effects.push_back(name);
+  }
+
+  attr = DynMemoryEffectOpInterfaceAttr::get(*p.getBuilder().getContext(),
+                                             effects);
+  return success();
+}
+
+namespace {
+void getEffectsConcept(
+    Operation *op,
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  auto dynCtx = op->getContext()->getLoadedDialect<dyn::DynamicContext>();
+  auto interface = dynCtx->lookupOpInterface(
+      mlir::MemoryEffectOpInterface::getInterfaceID());
+  assert(succeeded(interface) &&
+         "MemoryEffect concept is used but the interface was not declared");
+
+  auto interfaceImplGeneric = (*interface)->getImpl(op);
+  assert(succeeded(interfaceImplGeneric) &&
+         "MemoryEffect concept is used on an operation that doesn't have an "
+         "implementation the interface");
+
+  auto *interfaceImpl =
+      reinterpret_cast<DynMemoryEffectOpInterfaceImpl *>(*interfaceImplGeneric);
+  for (auto effect : interfaceImpl->effects)
+    effects.push_back(effect);
+}
+} // namespace
+
+void *DynMemoryEffectOpInterface::getConcept() {
+  return reinterpret_cast<void *>(
+      new (malloc(sizeof(
+          mlir::detail::MemoryEffectOpInterfaceInterfaceTraits::Concept)))
+          mlir::detail::MemoryEffectOpInterfaceInterfaceTraits::Concept{
+              getEffectsConcept});
+}
+
+FailureOr<dyn::DynamicOpInterfaceImpl *>
+DynMemoryEffectOpInterface::getImpl(Operation *op) {
+  auto ctx = op->getContext();
+  auto dynCtx = ctx->getLoadedDialect<dyn::DynamicContext>();
+
+  auto dynOpRes = dynCtx->lookupOp(op->getAbstractOperation()->typeID);
+  assert(succeeded(dynOpRes) &&
+         "Dynamic interfaces can only be used by dynamic operations.");
+  auto *dynOp = *dynOpRes;
+
+  return dynOp->getInterfaceImpl(this);
+}
+
+ParseResult DynMemoryEffectOpInterface::parseImpl(
+    OpAsmParser &p, InterfaceImplAttrInterface &attrInterface) {
+  DynMemoryEffectOpInterfaceAttr attr;
+  if (DynMemoryEffectOpInterfaceAttr::parse(p, attr))
+    return failure();
+  attrInterface = attr;
+  return success();
+}
+
+DynMemoryEffectOpInterfaceImpl::DynMemoryEffectOpInterfaceImpl(
+    dyn::DynamicContext *dynCtx,
+    std::vector<MemoryEffects::EffectInstance> effects)
+    : dyn::DynamicOpInterfaceImpl(*dynCtx->lookupOpInterface(
+          mlir::MemoryEffectOpInterface::getInterfaceID())),
+      effects(std::move(effects)) {}

--- a/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
+++ b/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
@@ -111,6 +111,11 @@ LogicalResult registerOperation(dyn::DynamicDialect *dialect, StringRef name,
     constraints.second.emplace_back(name, std::move(constraint));
   }
 
+  // Add the interfaces implementations.
+  std::vector<std::unique_ptr<dyn::DynamicOpInterfaceImpl>> interfaces;
+  for (auto interfaceAttr : opTypeDef.getInterfaceDefinitions())
+    interfaces.push_back(interfaceAttr.getInterfaceImpl());
+
   // Create the type verifier.
   auto typeVerifier =
       [constraints{std::make_shared<OpTypeConstraints>(std::move(constraints))},
@@ -119,7 +124,8 @@ LogicalResult registerOperation(dyn::DynamicDialect *dialect, StringRef name,
       };
 
   return dialect->createAndAddOperation(name, {std::move(typeVerifier)},
-                                        opTypeDef.traitDefs);
+                                        opTypeDef.traitDefs,
+                                        std::move(interfaces));
 }
 } // namespace irdl
 } // namespace mlir

--- a/lib/Dyn/DynamicContext.cpp
+++ b/lib/Dyn/DynamicContext.cpp
@@ -71,5 +71,19 @@ DynamicContext::registerOpTrait(llvm::StringRef name,
 
   typeIDToOpTraits.insert({opTraitPtr->getRuntimeTypeID(), opTraitPtr});
 
-  return inserted.first->second.get();
+  return opTraitPtr;
+}
+
+mlir::FailureOr<DynamicOpInterface *> DynamicContext::registerOpInterface(
+    llvm::StringRef name, std::unique_ptr<DynamicOpInterface> opInterface) {
+  auto opInterfacePtr = opInterface.get();
+
+  auto inserted = opInterfaces.try_emplace(name, std::move(opInterface));
+  if (!inserted.second)
+    return failure();
+
+  typeIDToOpInterfaces.insert(
+      {opInterfacePtr->getRuntimeTypeID(), opInterfacePtr});
+
+  return opInterfacePtr;
 }

--- a/test/Dyn/cmath.irdl
+++ b/test/Dyn/cmath.irdl
@@ -8,10 +8,10 @@ module {
         // CHECK: irdl.alias ccomplex = tuple<!cmath.real, !cmath.real>
         irdl.alias ccomplex = tuple<!cmath.real, !cmath.real>
         // CHECK: irdl.operation make_complex(re: !cmath.real, im: !cmath.real) -> (res: tuple<!cmath.real, !cmath.real>)
-        irdl.operation make_complex(re : real, im: real) -> (res: ccomplex)
-        irdl.operation mul(lhs: ccomplex, rhs: ccomplex) -> (res: ccomplex)
-        irdl.operation norm(c: ccomplex) -> (res: real)
-        irdl.operation get_real(c: ccomplex) -> (res: real)
-        irdl.operation get_imaginary(c: ccomplex) -> (res: real)
+        irdl.operation make_complex(re : real, im: real) -> (res: ccomplex) interfaces [MemoryEffect<>]
+        irdl.operation mul(lhs: ccomplex, rhs: ccomplex) -> (res: ccomplex) interfaces [MemoryEffect<>]
+        irdl.operation norm(c: ccomplex) -> (res: real) interfaces [MemoryEffect<>]
+        irdl.operation get_real(c: ccomplex) -> (res: real) interfaces [MemoryEffect<>]
+        irdl.operation get_imaginary(c: ccomplex) -> (res: real) interfaces [MemoryEffect<>]
     }
 }


### PR DESCRIPTION
As with traits, interfaces need to be added before parsing IRDL.
Though, they require significant boilerplate, compared to traits.

For now, only the MemoryEffect trait is implemented, which allow us to use the CSE pass for dead code elimination.