### PR TITLE
Allow to extend C++-defined dialects with dynamic types

### DIFF
--- a/include/Dyn/DynamicDialect.h
+++ b/include/Dyn/DynamicDialect.h
@@ -46,14 +46,6 @@ public:
 
   mlir::StringRef getName() const { return name; }
 
-  /// Create and register a new operation to the dialect.
-  /// The name of the operation should not begin with the name of the
-  /// dialect.
-  FailureOr<DynamicOperation *> createAndAddOperation(
-      llvm::StringRef name, std::vector<DynamicOperation::VerifierFn> verifiers,
-      std::vector<DynamicOpTrait *> traits,
-      std::vector<std::unique_ptr<DynamicOpInterfaceImpl>> interfaces);
-
   /// Create and add a new type to the dialect.
   /// The name of the type should not begin with the name of the dialect.
   FailureOr<DynamicTypeDefinition *> createAndAddType(StringRef name);
@@ -101,23 +93,6 @@ public:
     return lookupTypeAlias(name);
   }
 
-  /// The pointer is guaranteed to be non-null.
-  /// The name format should be 'dialect.operation'.
-  FailureOr<DynamicOperation *> lookupOp(StringRef name) const {
-    auto it = dynOps.find(name);
-    if (it == dynOps.end())
-      return failure();
-    return it->second.get();
-  }
-
-  /// The pointer is guaranteed to be non-null.
-  FailureOr<DynamicOperation *> lookupOp(TypeID id) const {
-    auto it = typeIDToDynOps.find(id);
-    if (it == typeIDToDynOps.end())
-      return failure();
-    return &*it->second;
-  }
-
 private:
   /// Name of the dialect.
   /// This name is used for parsing and printing.
@@ -130,14 +105,6 @@ private:
   /// This structure allows to get in O(1) a dynamic type given its typeID.
   /// This is useful for accessing the printer efficiently for instance.
   llvm::DenseMap<TypeID, DynamicTypeDefinition *> typeIDToDynTypes;
-
-  /// Dynamic operations registered in this dialect.
-  /// Their name is stored with the format `op` and not `dialect.op`.
-  llvm::StringMap<std::unique_ptr<DynamicOperation>> dynOps;
-
-  /// This structure allows to get in O(1) a dynamic type given its typeID.
-  /// This is useful for accessing the verifier efficiently for instance.
-  llvm::DenseMap<TypeID, DynamicOperation *> typeIDToDynOps;
 
   /// Type aliases registered in this dialect.
   /// Their name is stored with the format `alias` and not `dialect.alias`.

--- a/include/Dyn/DynamicOperation.h
+++ b/include/Dyn/DynamicOperation.h
@@ -15,6 +15,7 @@
 
 #include "Dyn/DynamicObject.h"
 #include "Dyn/DynamicTrait.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/STLExtras.h"
@@ -29,16 +30,16 @@ class DynamicOpInterfaceImpl;
 class DynamicOpInterface;
 
 /// Each instance of DynamicOperation correspond to a different operation.
-class DynamicOperation : public mlir::Op<DynamicOperation>,
-                         public DynamicObject {
+class DynamicOperation : public DynamicObject {
 public:
-  using VerifierFn = std::function<mlir::LogicalResult(mlir::Operation *op)>;
+  using VerifierFn =
+      llvm::unique_function<mlir::LogicalResult(mlir::Operation *op)>;
 
   /// Create a new dynamic operation given the operation name and the defining
   /// dialect.
   /// The operation name should be `operation` and not `dialect.operation`.
   DynamicOperation(
-      mlir::StringRef name, DynamicDialect *dialect,
+      mlir::StringRef name, Dialect *dialect, DynamicContext *ctx,
       std::vector<VerifierFn> verifiers, std::vector<DynamicOpTrait *> traits,
       std::vector<std::unique_ptr<DynamicOpInterfaceImpl>> interfaces);
 
@@ -65,6 +66,11 @@ public:
     return failure();
   }
 
+  /// Get the canonicalization patterns of this operation.
+  /// There is no way to define canonicalization patterns yet.
+  static void getCanonicalizationPatterns(OwningRewritePatternList &,
+                                          MLIRContext *ctx) {}
+
   /// Check if the operation has a specific trait given the trait TypeID.
   bool hasTrait(TypeID traitId);
 
@@ -74,12 +80,11 @@ private:
   /// Full name of the operation: `dialect.operation`.
   const std::string name;
 
-  /// Pointer to the dialect defining the operation.
-  DynamicDialect *dialect;
+  /// Dialect that defines this operation.
+  Dialect *dialect;
 
   /// Custom verifiers for the operation.
-  std::vector<std::function<mlir::LogicalResult(mlir::Operation *op)>>
-      verifiers;
+  std::vector<VerifierFn> verifiers;
 
   // Operation traits TypeID.
   std::vector<TypeID> traitsId;

--- a/include/Dyn/DynamicType.h
+++ b/include/Dyn/DynamicType.h
@@ -15,17 +15,23 @@
 
 #include "DynamicObject.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
 
 namespace mlir {
+
+// Forward declaration.
+class DialectAsmPrinter;
+class DialectAsmParser;
+
 namespace dyn {
 
 // Forward declaration.
 class DynamicDialect;
 
-/// This is the definition of a dynamic type. It stores the parser and printer.
-/// Each dynamic type instance refer to one instance of this class.
+/// This is the definition of a dynamic type. It stores the parser and
+/// printer. Each dynamic type instance refer to one instance of this class.
 class DynamicTypeDefinition : public DynamicObject {
 public:
   DynamicTypeDefinition(Dialect *dialect, llvm::StringRef name);
@@ -82,6 +88,22 @@ public:
   static bool isa(Type type, DynamicTypeDefinition *typeDef) {
     return type.getTypeID() == typeDef->getRuntimeTypeID();
   }
+
+  /// Parse the dynamic type 'typeName' in the dialect 'dialect'.
+  /// If there is no such dynamic type, returns no value.
+  /// If there is such dynamic type, then parse it, and returns the parse
+  /// result.
+  /// If this succeed, put the resulting type in 'resultType'.
+  static OptionalParseResult parseOptionalDynamicType(const Dialect *dialect,
+                                                      StringRef typeName,
+                                                      DialectAsmParser &parser,
+                                                      Type &resultType);
+
+  /// If 'type' is a dynamic type, print it.
+  /// Returns success if the type was printed, and failure if the type was not a
+  /// dynamic type.
+  static LogicalResult printIfDynamicType(Type type,
+                                          DialectAsmPrinter &printer);
 };
 
 } // namespace dyn

--- a/include/Dyn/DynamicType.h
+++ b/include/Dyn/DynamicType.h
@@ -28,10 +28,10 @@ class DynamicDialect;
 /// Each dynamic type instance refer to one instance of this class.
 class DynamicTypeDefinition : public DynamicObject {
 public:
-  DynamicTypeDefinition(DynamicDialect *dialect, llvm::StringRef name);
+  DynamicTypeDefinition(Dialect *dialect, llvm::StringRef name);
 
   /// Dialect in which this type is defined.
-  const DynamicDialect *dialect;
+  const Dialect *dialect;
 
   /// Name of the type.
   /// Does not contain the name of the dialect beforehand.

--- a/lib/Dyn/CAPI/IR.cpp
+++ b/lib/Dyn/CAPI/IR.cpp
@@ -34,14 +34,15 @@ void mlirDynamicDialectDestroy(MlirDynamicDialect dialect) {
 // Option: mlirDynamicOperationDestroy (not good).
 MlirDynamicOperation mlirDynamicOperationCreate(MlirStringRef name,
                                                 MlirDynamicDialect dialect) {
-  mlir::dyn::DynamicOperation *op =
-      new DynamicOperation(unwrap(name), unwrap(dialect), {}, {}, {});
-  return wrap(op);
+  auto res = unwrap(dialect)->getDynamicContext()->createAndRegisterOperation(
+      unwrap(name), unwrap(dialect), {}, {}, {});
+  assert(
+      succeeded(res) &&
+      "Trying to register a dynamic operation with an already existing name.");
+  return wrap(*res);
 }
 
-void mlirDynamicOperationDestroy(MlirDynamicOperation operation) {
-  delete unwrap(operation);
-}
+void mlirDynamicOperationDestroy(MlirDynamicOperation operation) {}
 
 MlirStringRef mlirDynamicOperationGetName(MlirDynamicOperation operation) {
   return wrap(unwrap(operation)->getName());

--- a/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDL.cpp
@@ -148,7 +148,8 @@ Optional<ParseResult> parseOptionalType(OpAsmParser &p, Type *type) {
                     "no 'irdl.dialect' currently being parsed.");
 
   /// Get the type from the dialect.
-  auto dynType = dialect->lookupTypeOrTypeAlias(typeName);
+  auto dynType = dynCtx->lookupTypeOrTypeAlias(
+      (dialect->getName() + "." + typeName).str());
   if (failed(dynType))
     return ParseResult(p.emitError(loc, "type ")
                            .append(typeName,

--- a/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
+++ b/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
@@ -27,12 +27,12 @@ using namespace irdl;
 namespace mlir {
 namespace irdl {
 LogicalResult registerType(dyn::DynamicDialect *dialect, StringRef name) {
-  return dialect->createAndAddType(name);
+  return dialect->getDynamicContext()->createAndRegisterType(name, dialect);
 }
 
 LogicalResult registerTypeAlias(dyn::DynamicDialect *dialect, StringRef name,
                                 Type type) {
-  return dialect->createAndAddTypeAlias(name, type);
+  return dialect->getDynamicContext()->addTypeAlias(name, dialect, type);
 }
 } // namespace irdl
 } // namespace mlir

--- a/lib/Dyn/DynamicType.cpp
+++ b/lib/Dyn/DynamicType.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dyn/DynamicType.h"
+#include "Dyn/DynamicContext.h"
 #include "Dyn/DynamicDialect.h"
 #include "mlir/IR/TypeSupport.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -18,10 +19,10 @@
 using namespace mlir;
 using namespace dyn;
 
-DynamicTypeDefinition::DynamicTypeDefinition(DynamicDialect *dialect,
+DynamicTypeDefinition::DynamicTypeDefinition(Dialect *dialect,
                                              llvm::StringRef name)
-    : DynamicObject(dialect->getDynamicContext()), dialect(dialect),
-      name(name.str()) {}
+    : DynamicObject(dialect->getContext()->getLoadedDialect<DynamicContext>()),
+      dialect(dialect), name(name.str()) {}
 
 DynamicTypeDefinition *DynamicType::getTypeDef() { return getImpl()->typeDef; }
 


### PR DESCRIPTION
We remove ownership of dynamic operations/types from dynamic dialects, to put them inside the dynamic context.
This, this allows to register dynamic operations/types in C++-defined dialects.
The users has still to modify the dialect printType and parseType functions to call the corresponding functions that are in DynamicType.

Thus, dynamic dialects are now only used to define a new dialect dynamically.