### PR TITLE
Type constraint variable

### DIFF
--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.h
@@ -47,8 +47,10 @@ using OwningTraitDefs =
 /// It contains the definition of every operand and result.
 class OpDef {
 public:
-  ArgDefs operandDef, resultDef;
+  ArgDefs typeConstraintVars, operandDef, resultDef;
   TraitDefs traitDefs;
+
+  ArgDefs getTypeConstraintVars() const { return typeConstraintVars; }
 
   /// Get the number of operands.
   std::size_t getNumOperands() const { return operandDef.size(); }
@@ -70,7 +72,8 @@ public:
 
   bool operator==(const OpDef &o) const {
     return o.operandDef == operandDef && o.resultDef == resultDef &&
-           o.traitDefs == traitDefs;
+           o.traitDefs == traitDefs &&
+           o.typeConstraintVars == typeConstraintVars;
   }
 
   friend llvm::hash_code hash_value(mlir::irdl::OpDef typeDef);
@@ -86,11 +89,14 @@ inline ArgDefs argDefAllocator(mlir::AttributeStorageAllocator &allocator,
 
 inline OpDef opDefAllocator(mlir::AttributeStorageAllocator &allocator,
                             OpDef typeDef) {
+  auto allocatedTypeConstrVars =
+      argDefAllocator(allocator, typeDef.typeConstraintVars);
   auto allocatedOperandDefs = argDefAllocator(allocator, typeDef.operandDef);
   auto allocatedResultDefs = argDefAllocator(allocator, typeDef.resultDef);
   auto allocatedTraitDefs = allocator.copyInto(typeDef.traitDefs);
 
-  return {allocatedOperandDefs, allocatedResultDefs, allocatedTraitDefs};
+  return {allocatedTypeConstrVars, allocatedOperandDefs, allocatedResultDefs,
+          allocatedTraitDefs};
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.td
+++ b/include/Dyn/Dialect/IRDL/IR/IRDLAttributes.td
@@ -58,6 +58,20 @@ def AnyOfTypeConstraintAttr : IRDL_AttrDef<"AnyOfTypeConstraintAttr", [TypeConst
   }];
 }
 
+def VarTypeConstraintAttr : IRDL_AttrDef<"VarTypeConstraintAttr", [TypeConstraintAttrInterface]> {
+  let summary = "Type constraint variable";
+  let description = [{
+    Attribute representing a type constraint variable.
+    All types matching the variable should be equal.
+    The first type matching the variable is the one setting the value.
+  }];
+  let parameters = (ins "size_t":$index);
+
+  let extraClassDeclaration = [{
+    std::unique_ptr<TypeConstraint> getTypeConstraint();
+  }];
+}
+
 def DynTypeParamsConstraintAttr : IRDL_AttrDef<"DynTypeParamsConstraintAttr", [TypeConstraintAttrInterface]> {
   let summary = "constraint on dynamic type parameters";
   let description = [{

--- a/include/Dyn/Dialect/IRDL/TypeConstraint.h
+++ b/include/Dyn/Dialect/IRDL/TypeConstraint.h
@@ -35,7 +35,7 @@ public:
   /// defined, or contains Type{} if the value is not set yet.
   virtual LogicalResult
   verifyType(function_ref<InFlightDiagnostic()> emitError, Type type,
-             ArrayRef<TypeConstraint *> typeConstraintVars,
+             ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
              MutableArrayRef<Type> varsValue) = 0;
 };
 
@@ -49,7 +49,7 @@ public:
 
   virtual LogicalResult
   verifyType(function_ref<InFlightDiagnostic()> emitError, Type type,
-             ArrayRef<TypeConstraint *> typeConstraintVars,
+             ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
              MutableArrayRef<Type> varsValue) override;
 
 private:
@@ -69,7 +69,7 @@ public:
 
   virtual LogicalResult
   verifyType(function_ref<InFlightDiagnostic()> emitError, Type type,
-             ArrayRef<TypeConstraint *> typeConstraintVars,
+             ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
              MutableArrayRef<Type> varsValue) override;
 
 private:
@@ -88,7 +88,7 @@ public:
 
   virtual LogicalResult
   verifyType(function_ref<InFlightDiagnostic()> emitError, Type type,
-             ArrayRef<TypeConstraint *> typeConstraintVars,
+             ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
              MutableArrayRef<Type> varsValue) override {
     return success();
   };
@@ -107,7 +107,7 @@ public:
 
   virtual LogicalResult
   verifyType(function_ref<InFlightDiagnostic()> emitError, Type type,
-             ArrayRef<TypeConstraint *> typeConstraintVars,
+             ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
              MutableArrayRef<Type> varsValue) override;
 
 private:
@@ -130,7 +130,7 @@ public:
 
   virtual LogicalResult
   verifyType(function_ref<InFlightDiagnostic()> emitError, Type type,
-             ArrayRef<TypeConstraint *> typeConstraintVars,
+             ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
              MutableArrayRef<Type> varsValue) override;
 
 private:

--- a/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
+++ b/lib/Dyn/Dialect/IRDL/IR/IRDLAttributes.cpp
@@ -67,6 +67,14 @@ std::unique_ptr<TypeConstraint> AnyTypeConstraintAttr::getTypeConstraint() {
 }
 
 //===----------------------------------------------------------------------===//
+// Type constraint variable
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<TypeConstraint> VarTypeConstraintAttr::getTypeConstraint() {
+  return std::make_unique<VarTypeConstraint>(getIndex());
+}
+
+//===----------------------------------------------------------------------===//
 // Attribute for constraint on dynamic type parameters
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
+++ b/lib/Dyn/Dialect/IRDL/IRDLRegistration.cpp
@@ -40,7 +40,7 @@ irdlTypeVerifier(function_ref<InFlightDiagnostic()> emitError,
 
   for (size_t i = 0; i < params.size(); i++) {
     if (failed(paramConstraints[i]->verifyType(
-            emitError, params[i].cast<TypeAttr>().getValue())))
+            emitError, params[i].cast<TypeAttr>().getValue(), {}, {})))
       return failure();
   }
   return success();
@@ -103,7 +103,7 @@ LogicalResult verifyOpDefConstraints(Operation *op,
   for (unsigned i = 0; i < numOperands; ++i) {
     auto operandType = op->getOperand(i).getType();
     auto &constraint = operandConstrs[i].second;
-    if (failed(constraint->verifyType(emitError, operandType)))
+    if (failed(constraint->verifyType(emitError, operandType, {}, {})))
       return failure();
   }
 
@@ -111,7 +111,7 @@ LogicalResult verifyOpDefConstraints(Operation *op,
   for (unsigned i = 0; i < numResults; ++i) {
     auto resultType = op->getResult(i).getType();
     auto &constraint = resultConstrs[i].second;
-    if (failed(constraint->verifyType(emitError, resultType)))
+    if (failed(constraint->verifyType(emitError, resultType, {}, {})))
       return failure();
   }
 

--- a/lib/Dyn/Dialect/IRDL/TypeConstraint.cpp
+++ b/lib/Dyn/Dialect/IRDL/TypeConstraint.cpp
@@ -17,11 +17,10 @@
 using namespace mlir;
 using namespace irdl;
 
-LogicalResult
-EqTypeConstraint::verifyType(function_ref<InFlightDiagnostic()> emitError,
-                             Type type,
-                             ArrayRef<TypeConstraint *> typeConstraintVars,
-                             MutableArrayRef<Type> varsValue) {
+LogicalResult EqTypeConstraint::verifyType(
+    function_ref<InFlightDiagnostic()> emitError, Type type,
+    ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
+    MutableArrayRef<Type> varsValue) {
   if (type == expectedType)
     return success();
 
@@ -29,22 +28,20 @@ EqTypeConstraint::verifyType(function_ref<InFlightDiagnostic()> emitError,
                             type);
 }
 
-LogicalResult
-AnyOfTypeConstraint::verifyType(function_ref<InFlightDiagnostic()> emitError,
-                                Type type,
-                                ArrayRef<TypeConstraint *> typeConstraintVars,
-                                MutableArrayRef<Type> varsValue) {
+LogicalResult AnyOfTypeConstraint::verifyType(
+    function_ref<InFlightDiagnostic()> emitError, Type type,
+    ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
+    MutableArrayRef<Type> varsValue) {
   if (std::find(types.begin(), types.end(), type) != types.end())
     return success();
 
   return emitError().append("type ", type, " does not satisfy the constraint");
 }
 
-LogicalResult
-VarTypeConstraint::verifyType(function_ref<InFlightDiagnostic()> emitError,
-                              Type type,
-                              ArrayRef<TypeConstraint *> typeConstraintVars,
-                              MutableArrayRef<Type> varsValue) {
+LogicalResult VarTypeConstraint::verifyType(
+    function_ref<InFlightDiagnostic()> emitError, Type type,
+    ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
+    MutableArrayRef<Type> varsValue) {
   assert(varIndex < typeConstraintVars.size() &&
          "type constraint variable index out of bounds");
   assert(typeConstraintVars.size() == varsValue.size() &&
@@ -76,7 +73,7 @@ VarTypeConstraint::verifyType(function_ref<InFlightDiagnostic()> emitError,
 
 LogicalResult DynTypeParamsConstraint::verifyType(
     function_ref<InFlightDiagnostic()> emitError, Type type,
-    ArrayRef<TypeConstraint *> typeConstraintVars,
+    ArrayRef<std::unique_ptr<TypeConstraint>> typeConstraintVars,
     MutableArrayRef<Type> varsValue) {
   auto dynType = type.dyn_cast<DynamicType>();
   if (!dynType || dynType.getTypeDef() != dynTypeDef)

--- a/test/Dyn/test-type-constraints.mlir
+++ b/test/Dyn/test-type-constraints.mlir
@@ -16,6 +16,9 @@ irdl.dialect testd {
 
     // CHECK: irdl.operation dynparams() -> (res: testd.parametric<irdl.AnyOf<i32, i64>>)
     irdl.operation dynparams() -> (res: testd.parametric<irdl.AnyOf<i32, i64>>)
+
+    // CHECK: irdl.operation typeConstrVars<a: irdl.AnyOf<i32, i64>>() -> (res1: a, res2: a)
+    irdl.operation typeConstrVars<a: irdl.AnyOf<i32, i64>>() -> (res1: a, res2: a)
 }
 
 // -----
@@ -95,3 +98,37 @@ func @failedDynParamsConstraint() {
     "testd.dynparams"() : () -> !testd.parametric<i1>
     return
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Type constraint variables
+//===----------------------------------------------------------------------===//
+
+func @succeededTypeConstraintVars() {
+     // CHECK: "testd.typeConstrVars"() : () -> (i32, i32)
+     "testd.typeConstrVars"() : () -> (i32, i32)
+     // CHECK: "testd.typeConstrVars"() : () -> (i64, i64)
+     "testd.typeConstrVars"() : () -> (i64, i64)
+     return
+}
+
+// -----
+
+// Check that the type constraint variables should respect the corresponding
+// constraint.
+func @failedTypeConstraintVarsConstraint() {
+     // expected-error@+1 {{type 'i1' does not satisfy the constraint}}
+     "testd.typeConstrVars"() : () -> (i1, i1)
+     return
+}
+
+// -----
+
+// Check that the type constraint variables should match equal types.
+func @failedTypeConstraintVarsConstraint() {
+     // expected-error@+1 {{expected 'i32' but got 'i64'}}
+     "testd.typeConstrVars"() : () -> (i32, i64)
+     return
+}
+


### PR DESCRIPTION
This PR adds type constraint variables, which are used to declare equality between types.
This allows to write something like : `irdl.operation my_op<t: AnyOf<i32, i64>>(a: t) -> (res: t)`. Both `a` and `res` should be of the same type, otherwise an error is raised. 