### PR TITLE
IRDL-Eval

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -91,6 +91,7 @@
         "typeinfo": "cpp",
         "valarray": "cpp",
         "variant": "cpp",
-        "*.def": "cpp"
-    }
+        "*.def": "cpp",
+        "*.rh": "cpp"
+    },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,8 +90,6 @@
         "typeindex": "cpp",
         "typeinfo": "cpp",
         "valarray": "cpp",
-        "variant": "cpp",
-        "*.def": "cpp",
-        "*.rh": "cpp"
+        "variant": "cpp"
     },
 }

--- a/dyn-opt/CMakeLists.txt
+++ b/dyn-opt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(LIBS
         ${conversion_libs}
         MLIROptLib
         )
-add_llvm_executable(dyn-opt dyn-opt.cpp MlirOptMain.cpp RegisterIRDL.cpp LowerIRDL.cpp)
+add_llvm_executable(dyn-opt dyn-opt.cpp MlirOptMain.cpp RegisterIRDL.cpp LowerIRDL.cpp GenEval.cpp)
 
 llvm_update_compile_flags(dyn-opt)
 target_link_libraries(dyn-opt PRIVATE ${LIBS})

--- a/dyn-opt/GenEval.cpp
+++ b/dyn-opt/GenEval.cpp
@@ -1,0 +1,458 @@
+//===- GenEval.cpp - Generates IRDL-Eval from IRDL-SSA ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Generates IRDL-Eval from IRDL-SSA definitions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "GenEval.h"
+
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEval.h"
+#include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSA.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include <iterator>
+
+using namespace mlir;
+using namespace irdleval;
+using namespace irdlssa;
+using namespace cf;
+
+struct ConstraintCheck {
+  Block *start;
+  Block *target;
+
+  Value constraint;
+  Value typeToCheck;
+};
+
+struct BacktrackPoint {
+  Block *toVisitWhenFails;
+  SmallVector<Value> slotsToClearWhenFails;
+
+  Block &generateBacktrackBlock(Location loc, Region &region,
+                                IRRewriter &rewriter);
+};
+
+Block &BacktrackPoint::generateBacktrackBlock(Location loc, Region &region,
+                                              IRRewriter &rewriter) {
+  // Save current insertion point
+  auto ipBackupBlock = rewriter.getInsertionBlock();
+  auto ipBackup = rewriter.getInsertionPoint();
+
+  Block &btBlock = region.emplaceBlock();
+  rewriter.setInsertionPointToEnd(&btBlock);
+  for (Value slot : this->slotsToClearWhenFails) {
+    rewriter.create<Eval_ClearType>(loc, slot);
+  }
+  rewriter.create<BranchOp>(loc, this->toVisitWhenFails);
+
+  rewriter.setInsertionPoint(ipBackupBlock, ipBackup);
+  return btBlock;
+}
+
+struct ConstraintCheckCompileJob {
+  /// Stack containing the constraint checking
+  /// left to compile. The target block of a ConstraintCheck
+  /// in the stack must be equal to the start block of
+  /// the next item in unstacking order if it exists and
+  /// in that case must be empty.
+  SmallVector<ConstraintCheck> workStack;
+  BacktrackPoint btPoint;
+  SmallPtrSet<Value, 8> definedSlots;
+
+  bool workStackInvariant() const;
+};
+
+bool ConstraintCheckCompileJob::workStackInvariant() const {
+  for (size_t i = 1; i < this->workStack.size(); i++) {
+    if (this->workStack[i - 1].start != this->workStack[i].target) {
+      return false;
+    } else if (this->workStack[i].target->getOperations().size() != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+class ConstraintCompiler {
+public:
+  static void compile(MLIRContext *ctx, Block &constraints,
+                      IRRewriter &rewriter, Location location,
+                      ArrayRef<Value> args);
+
+private:
+  ConstraintCompiler(MLIRContext *ctx, Region &region, Block &constraints,
+                     IRRewriter &rewriter, Location location)
+      : ctx(ctx), region(region), constraints(constraints), rewriter(rewriter),
+        location(location) {}
+
+  void compileAnyType(ConstraintCheck &checkDesc, Value slot,
+                      ConstraintCheckCompileJob &currentJob);
+  void compileIsType(ConstraintCheck &checkDesc, Value slot,
+                     ConstraintCheckCompileJob &currentJob,
+                     ParamTypeAttrOrAnyAttr expected);
+  void compileParametricType(ConstraintCheck &checkDesc, Value slot,
+                             ConstraintCheckCompileJob &currentJob,
+                             StringRef base, ArrayRef<Value> argConstraints);
+  void compileAnyOf(ConstraintCheck &checkDesc, Value slot,
+                    ConstraintCheckCompileJob &currentJob,
+                    ArrayRef<Value> argConstraints);
+
+  bool workStackInvariant() const;
+
+  SmallVector<ConstraintCheckCompileJob> compileJobs;
+  MLIRContext *ctx;
+  Region &region;
+  Block &constraints;
+  IRRewriter &rewriter;
+  Location location;
+};
+
+void ConstraintCompiler::compileAnyType(ConstraintCheck &checkDesc, Value slot,
+                                        ConstraintCheckCompileJob &currentJob) {
+  rewriter.setInsertionPointToEnd(checkDesc.start);
+  if (currentJob.definedSlots.contains(slot)) {
+    Block &failure = currentJob.btPoint.generateBacktrackBlock(
+        this->location, this->region, rewriter);
+    rewriter.create<Eval_MatchType>(this->location, slot, checkDesc.typeToCheck,
+                                    checkDesc.target, &failure);
+  } else {
+    rewriter.create<Eval_AssignType>(this->location, slot,
+                                     checkDesc.typeToCheck);
+    rewriter.create<BranchOp>(this->location, checkDesc.target);
+    currentJob.definedSlots.insert(slot);
+    currentJob.btPoint.slotsToClearWhenFails.push_back(slot);
+  }
+}
+
+void ConstraintCompiler::compileIsType(ConstraintCheck &checkDesc, Value slot,
+                                       ConstraintCheckCompileJob &currentJob,
+                                       ParamTypeAttrOrAnyAttr expected) {
+  Block &failure = currentJob.btPoint.generateBacktrackBlock(
+      this->location, this->region, rewriter);
+  rewriter.setInsertionPointToEnd(checkDesc.start);
+  rewriter.create<Eval_CheckType>(this->location, checkDesc.typeToCheck,
+                                  expected, checkDesc.target, &failure);
+}
+
+void ConstraintCompiler::compileParametricType(
+    ConstraintCheck &checkDesc, Value slot,
+    ConstraintCheckCompileJob &currentJob, StringRef base,
+    ArrayRef<Value> argConstraints) {
+  Block &failure = currentJob.btPoint.generateBacktrackBlock(
+      this->location, this->region, rewriter);
+  rewriter.setInsertionPointToEnd(checkDesc.start);
+  if (currentJob.definedSlots.contains(slot)) {
+    rewriter.create<Eval_MatchType>(this->location, slot, checkDesc.typeToCheck,
+                                    checkDesc.target, &failure);
+  } else {
+    Block &parametricSuccess = region.emplaceBlock();
+    SmallVector<Type> argTypes(argConstraints.size(),
+                               EvalTypeType::get(this->ctx));
+    SmallVector<Location> argLocs(argConstraints.size(), this->location);
+    parametricSuccess.addArguments(argTypes, argLocs);
+    rewriter.create<Eval_CheckParametric>(this->location, checkDesc.typeToCheck,
+                                          base, &parametricSuccess, &failure);
+
+    rewriter.setInsertionPointToEnd(&parametricSuccess);
+    rewriter.create<Eval_AssignType>(this->location, slot,
+                                     checkDesc.typeToCheck);
+    currentJob.definedSlots.insert(slot);
+    currentJob.btPoint.slotsToClearWhenFails.push_back(slot);
+
+    Block *start = &parametricSuccess;
+    Block *target;
+    SmallVector<ConstraintCheck> newChecks;
+    for (size_t i = 0; i + 1 < argConstraints.size(); i++) {
+      target = &region.emplaceBlock();
+      newChecks.push_back({
+          .start = start,
+          .target = target,
+          .constraint = argConstraints[i],
+          .typeToCheck = parametricSuccess.getArgument(i),
+      });
+      start = target;
+    }
+
+    newChecks.push_back({
+        .start = start,
+        .target = checkDesc.target,
+        .constraint = argConstraints[argConstraints.size() - 1],
+        .typeToCheck = parametricSuccess.getArgument(argConstraints.size() - 1),
+    });
+
+    currentJob.workStack.append(newChecks.rbegin(), newChecks.rend());
+  }
+}
+
+void ConstraintCompiler::compileAnyOf(ConstraintCheck &checkDesc, Value slot,
+                                      ConstraintCheckCompileJob &currentJob,
+                                      ArrayRef<Value> argConstraints) {
+  if (currentJob.definedSlots.contains(slot)) {
+    Block &failure = currentJob.btPoint.generateBacktrackBlock(
+        this->location, this->region, rewriter);
+    rewriter.setInsertionPointToEnd(checkDesc.start);
+    rewriter.create<Eval_MatchType>(this->location, slot, checkDesc.typeToCheck,
+                                    checkDesc.target, &failure);
+  } else {
+    if (argConstraints.size() == 0) {
+      Block &failure = currentJob.btPoint.generateBacktrackBlock(
+          this->location, this->region, rewriter);
+      rewriter.setInsertionPointToEnd(checkDesc.start);
+      rewriter.create<BranchOp>(this->location, &failure);
+    } else {
+      rewriter.setInsertionPointToEnd(checkDesc.start);
+      rewriter.create<Eval_AssignType>(this->location, slot,
+                                       checkDesc.typeToCheck);
+      currentJob.definedSlots.insert(slot);
+      currentJob.btPoint.slotsToClearWhenFails.push_back(slot);
+
+      SmallVector<BacktrackPoint> backtrackPoints;
+      for (size_t i = 0; i + 1 < argConstraints.size(); i++) {
+        backtrackPoints.push_back(
+            {.toVisitWhenFails = &this->region.emplaceBlock(),
+             .slotsToClearWhenFails = {}});
+      }
+      backtrackPoints.push_back(std::move(currentJob.btPoint));
+
+      for (size_t i = 1; i < argConstraints.size(); i++) {
+        SmallVector<ConstraintCheck> newWorkStack = currentJob.workStack;
+        DenseMap<Block *, Block *> blockTransl;
+
+        // Copy work item start blocks
+        for (size_t i = 0; i < currentJob.workStack.size(); i++) {
+          // This is guaranteed by the linked structure of the stack.
+          assert(blockTransl.count(currentJob.workStack[i].start) == 0 &&
+                 "repeated start block for work stack item");
+          assert(currentJob.workStack[i].start->getOperations().size() == 0 &&
+                 "work stack block is not empty");
+
+          blockTransl.insert(
+              {currentJob.workStack[i].start, &region.emplaceBlock()});
+          newWorkStack[i].start = blockTransl[currentJob.workStack[i].start];
+        }
+
+        // Update all targets except the last one
+        for (size_t i = 1; i < currentJob.workStack.size(); i++) {
+          // This is guaranteed by the linked structure of the stack.
+          assert(blockTransl.count(currentJob.workStack[i].target) == 1 &&
+                 "invalid successor for work stack item");
+
+          newWorkStack[i].target = blockTransl[currentJob.workStack[i].target];
+        }
+
+        Block *target = checkDesc.target;
+        if (blockTransl.count(checkDesc.target) == 1) {
+          target = blockTransl[checkDesc.target];
+        }
+
+        newWorkStack.push_back(
+            {.start = backtrackPoints[i - 1].toVisitWhenFails,
+             .target = target,
+             .constraint = argConstraints[i],
+             .typeToCheck = checkDesc.typeToCheck});
+        this->compileJobs.push_back({
+            .workStack = std::move(newWorkStack),
+            .btPoint = std::move(backtrackPoints[i]),
+            .definedSlots = currentJob.definedSlots,
+        });
+      }
+
+      currentJob.workStack.push_back({.start = checkDesc.start,
+                                      .target = checkDesc.target,
+                                      .constraint = argConstraints[0],
+                                      .typeToCheck = checkDesc.typeToCheck});
+      currentJob.btPoint = std::move(backtrackPoints[0]);
+    }
+  }
+}
+
+bool ConstraintCompiler::workStackInvariant() const {
+  for (ConstraintCheckCompileJob const &job : this->compileJobs) {
+    if (!job.workStackInvariant()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void ConstraintCompiler::compile(MLIRContext *ctx, Block &constraints,
+                                 IRRewriter &rewriter, Location location,
+                                 ArrayRef<Value> args) {
+  rewriter.setInsertionPointToEnd(&constraints);
+  auto verifierOp = rewriter.create<Eval_Verifier>(location);
+
+  Region &region = verifierOp.body();
+
+  SmallVector<Type> argTypes(args.size(), EvalTypeType::get(ctx));
+  SmallVector<Location> argLocs(args.size(), location);
+  Block &start = region.emplaceBlock();
+  start.addArguments(argTypes, argLocs);
+
+  if (args.size() == 0) {
+    rewriter.setInsertionPointToStart(&start);
+    rewriter.create<Eval_Success>(location);
+    return;
+  }
+
+  rewriter.setInsertionPointToStart(&start);
+  DenseMap<Value, Value> cstrToSlot;
+  for (Operation &op : constraints.getOperations()) {
+    if (llvm::isa<VerifyConstraintInterface>(op)) {
+      Eval_Alloca alloca =
+          rewriter.create<Eval_Alloca>(location, SlotType::get(ctx));
+      cstrToSlot.insert({op.getResult(0), alloca.getResult()});
+    }
+  }
+
+  Block &success = region.emplaceBlock();
+  rewriter.setInsertionPointToStart(&success);
+  rewriter.create<Eval_Success>(location);
+
+  Block &failure = region.emplaceBlock();
+  rewriter.setInsertionPointToStart(&failure);
+  rewriter.create<Eval_Failure>(location);
+
+  ConstraintCompiler compiler(ctx, region, constraints, rewriter, location);
+
+  SmallVector<ConstraintCheck> argToWork;
+  Block *workStart = &start;
+  for (size_t i = 0; i < args.size() - 1; i++) {
+    Block *workTarget = &region.emplaceBlock();
+    argToWork.push_back({
+        .start = workStart,
+        .target = workTarget,
+        .constraint = args[i],
+        .typeToCheck = start.getArgument(i),
+    });
+    workStart = workTarget;
+  }
+  argToWork.push_back({
+      .start = workStart,
+      .target = &success,
+      .constraint = args[args.size() - 1],
+      .typeToCheck = start.getArgument(args.size() - 1),
+  });
+
+  compiler.compileJobs.push_back({
+      .workStack = {argToWork.rbegin(), argToWork.rend()},
+      .btPoint =
+          {
+              .toVisitWhenFails = &failure,
+              .slotsToClearWhenFails = {},
+          },
+      .definedSlots = {},
+  });
+
+  while (compiler.compileJobs.size() != 0) {
+    assert(compiler.workStackInvariant() &&
+           "work stack invariant is not respected for jobs");
+
+    ConstraintCheckCompileJob currentJob =
+        std::move(compiler.compileJobs.back());
+    compiler.compileJobs.pop_back();
+
+    while (currentJob.workStack.size() != 0) {
+      assert(currentJob.workStackInvariant() &&
+             "work stack invariant is not respected for current job");
+
+      ConstraintCheck currentCheck = std::move(currentJob.workStack.back());
+      currentJob.workStack.pop_back();
+
+      TypeSwitch<Operation *>(currentCheck.constraint.getDefiningOp())
+          .Case<SSA_AnyType>([&](SSA_AnyType op) {
+            compiler.compileAnyType(
+                currentCheck, cstrToSlot[currentCheck.constraint], currentJob);
+          })
+          .Case<SSA_IsType>([&](SSA_IsType op) {
+            compiler.compileIsType(currentCheck,
+                                   cstrToSlot[currentCheck.constraint],
+                                   currentJob, op.type());
+          })
+          .Case<SSA_ParametricType>([&](SSA_ParametricType op) {
+            SmallVector<Value> args = op.args();
+            compiler.compileParametricType(currentCheck,
+                                           cstrToSlot[currentCheck.constraint],
+                                           currentJob, op.type(), args);
+          })
+          .Case<SSA_AnyOf>([&](SSA_AnyOf op) {
+            SmallVector<Value> args = op.args();
+            compiler.compileAnyOf(currentCheck,
+                                  cstrToSlot[currentCheck.constraint],
+                                  currentJob, args);
+          })
+          .Default([](Operation *op) { assert(0 && "unsupported operation"); });
+    }
+  }
+}
+
+void GenEval::runOnOperation() {
+  IRRewriter rewriter(&this->getContext());
+
+  SSA_DialectOp op = this->getOperation();
+
+  op.walk([&](SSA_TypeOp op) {
+    for (Operation &child : op.getOps()) {
+      if (llvm::isa<Eval_Verifier>(child)) {
+        return;
+      }
+    }
+
+    SmallVector<Value> args;
+    for (Operation &op : op.getRegion().getOps()) {
+      if (SSA_ParametersOp paramOp = llvm::dyn_cast<SSA_ParametersOp>(op)) {
+        for (auto arg : paramOp.args()) {
+          args.push_back(arg);
+        }
+      }
+    }
+
+    ConstraintCompiler::compile(&this->getContext(),
+                                op.body().getBlocks().front(), rewriter,
+                                op.getLoc(), args);
+  });
+
+  op.walk([&](SSA_OperationOp op) {
+    for (Operation &child : op.getOps()) {
+      if (llvm::isa<Eval_Verifier>(child)) {
+        return;
+      }
+    }
+
+    SSA_OperandsOp operOp;
+    SSA_ResultsOp resOp;
+    for (Operation &op : op.getRegion().getOps()) {
+      if (SSA_OperandsOp opFound = llvm::dyn_cast<SSA_OperandsOp>(op)) {
+        operOp = opFound;
+      } else if (SSA_ResultsOp opFound = llvm::dyn_cast<SSA_ResultsOp>(op)) {
+        resOp = opFound;
+      }
+    }
+
+    SmallVector<Value> args;
+    if (operOp) {
+      for (auto arg : operOp.args()) {
+        args.push_back(arg);
+      }
+    }
+
+    if (resOp) {
+      for (auto arg : resOp.args()) {
+        args.push_back(arg);
+      }
+    }
+
+    ConstraintCompiler::compile(&this->getContext(),
+                                op.body().getBlocks().front(), rewriter,
+                                op.getLoc(), args);
+  });
+}

--- a/dyn-opt/GenEval.cpp
+++ b/dyn-opt/GenEval.cpp
@@ -24,7 +24,19 @@ using namespace irdleval;
 using namespace irdlssa;
 using namespace cf;
 
+namespace {
+
+/// Represents a constraint check generation work item.
+/// Tasks the compiler to generate in block `start` a
+/// verifier for `constraint` against `typeToCheck`,
+/// going to `target` if successful or to the
+/// contextual backtrack point if unsuccessful.
 struct ConstraintCheck {
+  ConstraintCheck(Block *start, Block *target, Value constraint,
+                  Value typeToCheck)
+      : start(start), target(target), constraint(constraint),
+        typeToCheck(typeToCheck) {}
+
   Block *start;
   Block *target;
 
@@ -32,55 +44,60 @@ struct ConstraintCheck {
   Value typeToCheck;
 };
 
+/// Represents a point at which the upcoming tasks
+/// must go back to when they fail.
 struct BacktrackPoint {
+  BacktrackPoint(Block *toVisitWhenFails,
+                 SmallVector<Value> slotsToClearWhenFails = {})
+      : toVisitWhenFails(toVisitWhenFails),
+        slotsToClearWhenFails(std::move(slotsToClearWhenFails)) {}
+
   Block *toVisitWhenFails;
+
+  /// Lists of slots that must have been cleared
+  /// before jumping to the failure-case block.
+  /// This list is expanded as compiling jobs define
+  /// new slots in their execution.
   SmallVector<Value> slotsToClearWhenFails;
 
+  /// Generates a block that cleans up the slots
+  /// to clear before jumping to `toVisitWhenFails`.
+  /// This block should be generated for each instruction
+  /// as a target in case of failure, in order to account
+  /// for newly added slots.
   Block &generateBacktrackBlock(Location loc, Region &region,
                                 IRRewriter &rewriter);
 };
 
-Block &BacktrackPoint::generateBacktrackBlock(Location loc, Region &region,
-                                              IRRewriter &rewriter) {
-  // Save current insertion point
-  auto ipBackupBlock = rewriter.getInsertionBlock();
-  auto ipBackup = rewriter.getInsertionPoint();
-
-  Block &btBlock = region.emplaceBlock();
-  rewriter.setInsertionPointToEnd(&btBlock);
-  for (Value slot : this->slotsToClearWhenFails) {
-    rewriter.create<Eval_ClearType>(loc, slot);
-  }
-  rewriter.create<BranchOp>(loc, this->toVisitWhenFails);
-
-  rewriter.setInsertionPoint(ipBackupBlock, ipBackup);
-  return btBlock;
-}
-
+/// Collection of work items with a shared backtrack point.
 struct ConstraintCheckCompileJob {
-  /// Stack containing the constraint checking
+  ConstraintCheckCompileJob(SmallVector<ConstraintCheck> workStack,
+                            BacktrackPoint btPoint,
+                            SmallPtrSet<Value, 8> definedSlots = {})
+      : workStack(std::move(workStack)), btPoint(std::move(btPoint)),
+        definedSlots(std::move(definedSlots)) {}
+
+  /// Stack containing the constraint checks
   /// left to compile. The target block of a ConstraintCheck
   /// in the stack must be equal to the start block of
   /// the next item in unstacking order if it exists and
   /// in that case must be empty.
   SmallVector<ConstraintCheck> workStack;
+
+  /// Backtrack point for items in the work stack to
+  /// jump to in case of failure.
   BacktrackPoint btPoint;
+
+  /// Lists all slot that are currently known to be
+  /// defined in this context.
+  /// This list is expanded as compiling jobs define
+  /// new slots in their execution.
   SmallPtrSet<Value, 8> definedSlots;
 
+  /// Ensures the work stack linking invariant upholds
+  /// for debug assert purposes.
   bool workStackInvariant() const;
 };
-
-bool ConstraintCheckCompileJob::workStackInvariant() const {
-  for (size_t i = 1; i < this->workStack.size(); i++) {
-    if (this->workStack[i - 1].start != this->workStack[i].target) {
-      return false;
-    } else if (this->workStack[i].target->getOperations().size() != 0) {
-      return false;
-    }
-  }
-
-  return true;
-}
 
 class ConstraintCompiler {
 public:
@@ -106,6 +123,8 @@ private:
                     ConstraintCheckCompileJob &currentJob,
                     ArrayRef<Value> argConstraints);
 
+  /// Ensures the work stack linking invariant upholds
+  /// in every registered job for debug assert purposes.
   bool workStackInvariant() const;
 
   SmallVector<ConstraintCheckCompileJob> compileJobs;
@@ -116,17 +135,48 @@ private:
   Location location;
 };
 
+} // namespace
+
+Block &BacktrackPoint::generateBacktrackBlock(Location loc, Region &region,
+                                              IRRewriter &rewriter) {
+  // Save current insertion point
+  auto ipBackupBlock = rewriter.getInsertionBlock();
+  auto ipBackup = rewriter.getInsertionPoint();
+
+  Block &btBlock = region.emplaceBlock();
+  rewriter.setInsertionPointToEnd(&btBlock);
+  for (Value slot : this->slotsToClearWhenFails) {
+    rewriter.create<ClearType>(loc, slot);
+  }
+  rewriter.create<BranchOp>(loc, this->toVisitWhenFails);
+
+  // Restore insertion point
+  rewriter.setInsertionPoint(ipBackupBlock, ipBackup);
+  return btBlock;
+}
+
+bool ConstraintCheckCompileJob::workStackInvariant() const {
+  for (size_t i = 1; i < this->workStack.size(); i++) {
+    if (this->workStack[i - 1].start != this->workStack[i].target) {
+      return false;
+    } else if (this->workStack[i].target->getOperations().size() != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 void ConstraintCompiler::compileAnyType(ConstraintCheck &checkDesc, Value slot,
                                         ConstraintCheckCompileJob &currentJob) {
   rewriter.setInsertionPointToEnd(checkDesc.start);
   if (currentJob.definedSlots.contains(slot)) {
     Block &failure = currentJob.btPoint.generateBacktrackBlock(
         this->location, this->region, rewriter);
-    rewriter.create<Eval_MatchType>(this->location, slot, checkDesc.typeToCheck,
-                                    checkDesc.target, &failure);
+    rewriter.create<MatchType>(this->location, slot, checkDesc.typeToCheck,
+                               checkDesc.target, &failure);
   } else {
-    rewriter.create<Eval_AssignType>(this->location, slot,
-                                     checkDesc.typeToCheck);
+    rewriter.create<AssignType>(this->location, slot, checkDesc.typeToCheck);
     rewriter.create<BranchOp>(this->location, checkDesc.target);
     currentJob.definedSlots.insert(slot);
     currentJob.btPoint.slotsToClearWhenFails.push_back(slot);
@@ -139,8 +189,8 @@ void ConstraintCompiler::compileIsType(ConstraintCheck &checkDesc, Value slot,
   Block &failure = currentJob.btPoint.generateBacktrackBlock(
       this->location, this->region, rewriter);
   rewriter.setInsertionPointToEnd(checkDesc.start);
-  rewriter.create<Eval_CheckType>(this->location, checkDesc.typeToCheck,
-                                  expected, checkDesc.target, &failure);
+  rewriter.create<CheckType>(this->location, checkDesc.typeToCheck, expected,
+                             checkDesc.target, &failure);
 }
 
 void ConstraintCompiler::compileParametricType(
@@ -151,43 +201,39 @@ void ConstraintCompiler::compileParametricType(
       this->location, this->region, rewriter);
   rewriter.setInsertionPointToEnd(checkDesc.start);
   if (currentJob.definedSlots.contains(slot)) {
-    rewriter.create<Eval_MatchType>(this->location, slot, checkDesc.typeToCheck,
-                                    checkDesc.target, &failure);
+    rewriter.create<MatchType>(this->location, slot, checkDesc.typeToCheck,
+                               checkDesc.target, &failure);
   } else {
     Block &parametricSuccess = region.emplaceBlock();
     SmallVector<Type> argTypes(argConstraints.size(),
                                EvalTypeType::get(this->ctx));
     SmallVector<Location> argLocs(argConstraints.size(), this->location);
     parametricSuccess.addArguments(argTypes, argLocs);
-    rewriter.create<Eval_CheckParametric>(this->location, checkDesc.typeToCheck,
-                                          base, &parametricSuccess, &failure);
+    rewriter.create<CheckParametric>(this->location, checkDesc.typeToCheck,
+                                     base, &parametricSuccess, &failure);
 
+    // Pre-assign the type in the slot table as if the constraint
+    // check succeeded. This is correct because further parameter
+    // checks cannot reference this slot anyway.
     rewriter.setInsertionPointToEnd(&parametricSuccess);
-    rewriter.create<Eval_AssignType>(this->location, slot,
-                                     checkDesc.typeToCheck);
+    rewriter.create<AssignType>(this->location, slot, checkDesc.typeToCheck);
     currentJob.definedSlots.insert(slot);
     currentJob.btPoint.slotsToClearWhenFails.push_back(slot);
 
+    // Schedule type-parameter checking work items.
     Block *start = &parametricSuccess;
     Block *target;
     SmallVector<ConstraintCheck> newChecks;
     for (size_t i = 0; i + 1 < argConstraints.size(); i++) {
       target = &region.emplaceBlock();
-      newChecks.push_back({
-          .start = start,
-          .target = target,
-          .constraint = argConstraints[i],
-          .typeToCheck = parametricSuccess.getArgument(i),
-      });
+      newChecks.emplace_back(start, target, argConstraints[i],
+                             parametricSuccess.getArgument(i));
       start = target;
     }
 
-    newChecks.push_back({
-        .start = start,
-        .target = checkDesc.target,
-        .constraint = argConstraints[argConstraints.size() - 1],
-        .typeToCheck = parametricSuccess.getArgument(argConstraints.size() - 1),
-    });
+    newChecks.emplace_back(
+        start, checkDesc.target, argConstraints[argConstraints.size() - 1],
+        parametricSuccess.getArgument(argConstraints.size() - 1));
 
     currentJob.workStack.append(newChecks.rbegin(), newChecks.rend());
   }
@@ -200,78 +246,101 @@ void ConstraintCompiler::compileAnyOf(ConstraintCheck &checkDesc, Value slot,
     Block &failure = currentJob.btPoint.generateBacktrackBlock(
         this->location, this->region, rewriter);
     rewriter.setInsertionPointToEnd(checkDesc.start);
-    rewriter.create<Eval_MatchType>(this->location, slot, checkDesc.typeToCheck,
-                                    checkDesc.target, &failure);
+    rewriter.create<MatchType>(this->location, slot, checkDesc.typeToCheck,
+                               checkDesc.target, &failure);
   } else {
     if (argConstraints.size() == 0) {
+      // Simple failure for trivial AnyOf constraints
       Block &failure = currentJob.btPoint.generateBacktrackBlock(
           this->location, this->region, rewriter);
       rewriter.setInsertionPointToEnd(checkDesc.start);
       rewriter.create<BranchOp>(this->location, &failure);
-    } else {
-      rewriter.setInsertionPointToEnd(checkDesc.start);
-      rewriter.create<Eval_AssignType>(this->location, slot,
-                                       checkDesc.typeToCheck);
-      currentJob.definedSlots.insert(slot);
-      currentJob.btPoint.slotsToClearWhenFails.push_back(slot);
-
-      SmallVector<BacktrackPoint> backtrackPoints;
-      for (size_t i = 0; i + 1 < argConstraints.size(); i++) {
-        backtrackPoints.push_back(
-            {.toVisitWhenFails = &this->region.emplaceBlock(),
-             .slotsToClearWhenFails = {}});
-      }
-      backtrackPoints.push_back(std::move(currentJob.btPoint));
-
-      for (size_t i = 1; i < argConstraints.size(); i++) {
-        SmallVector<ConstraintCheck> newWorkStack = currentJob.workStack;
-        DenseMap<Block *, Block *> blockTransl;
-
-        // Copy work item start blocks
-        for (size_t i = 0; i < currentJob.workStack.size(); i++) {
-          // This is guaranteed by the linked structure of the stack.
-          assert(blockTransl.count(currentJob.workStack[i].start) == 0 &&
-                 "repeated start block for work stack item");
-          assert(currentJob.workStack[i].start->getOperations().size() == 0 &&
-                 "work stack block is not empty");
-
-          blockTransl.insert(
-              {currentJob.workStack[i].start, &region.emplaceBlock()});
-          newWorkStack[i].start = blockTransl[currentJob.workStack[i].start];
-        }
-
-        // Update all targets except the last one
-        for (size_t i = 1; i < currentJob.workStack.size(); i++) {
-          // This is guaranteed by the linked structure of the stack.
-          assert(blockTransl.count(currentJob.workStack[i].target) == 1 &&
-                 "invalid successor for work stack item");
-
-          newWorkStack[i].target = blockTransl[currentJob.workStack[i].target];
-        }
-
-        Block *target = checkDesc.target;
-        if (blockTransl.count(checkDesc.target) == 1) {
-          target = blockTransl[checkDesc.target];
-        }
-
-        newWorkStack.push_back(
-            {.start = backtrackPoints[i - 1].toVisitWhenFails,
-             .target = target,
-             .constraint = argConstraints[i],
-             .typeToCheck = checkDesc.typeToCheck});
-        this->compileJobs.push_back({
-            .workStack = std::move(newWorkStack),
-            .btPoint = std::move(backtrackPoints[i]),
-            .definedSlots = currentJob.definedSlots,
-        });
-      }
-
-      currentJob.workStack.push_back({.start = checkDesc.start,
-                                      .target = checkDesc.target,
-                                      .constraint = argConstraints[0],
-                                      .typeToCheck = checkDesc.typeToCheck});
-      currentJob.btPoint = std::move(backtrackPoints[0]);
+      return;
     }
+
+    // Pre-assign the type in the slot table as if the constraint
+    // check succeeded. This is correct because further parameter
+    // checks cannot reference this slot anyway.
+    rewriter.setInsertionPointToEnd(checkDesc.start);
+    rewriter.create<AssignType>(this->location, slot, checkDesc.typeToCheck);
+    currentJob.definedSlots.insert(slot);
+    currentJob.btPoint.slotsToClearWhenFails.push_back(slot);
+
+    // AnyOf constraints are checked by attempting to go as deep
+    // as possible in a branch, and backtracking to the next branch
+    // if anything failed while exploring the attempted branch.
+    // This is achieved in the compiler by created a compile job
+    // for each branch and its initial constraint check, each job
+    // holding a copy of the initial work stack, with a different
+    // backtracking point.
+
+    // Prepare the backtrack points for all possible AnyOf branch
+    SmallVector<BacktrackPoint> backtrackPoints;
+    for (size_t i = 0; i + 1 < argConstraints.size(); i++) {
+      backtrackPoints.emplace_back(&this->region.emplaceBlock());
+    }
+    backtrackPoints.push_back(std::move(currentJob.btPoint));
+
+    // Create new work stacks for all possible AnyOf branch
+    // except the first one. The first one will re-use the
+    // original work stack for efficiency.
+    // This is achieved by duplicating all blocks in the work
+    // stacks and linking them correctly.
+    for (size_t i = 1; i < argConstraints.size(); i++) {
+      SmallVector<ConstraintCheck> newWorkStack = currentJob.workStack;
+      DenseMap<Block *, Block *> blockTransl;
+
+      // Copy work item start blocks
+      for (size_t i = 0; i < currentJob.workStack.size(); i++) {
+        // This is guaranteed by the linked structure of the stack.
+        assert(blockTransl.count(currentJob.workStack[i].start) == 0 &&
+               "repeated start block for work stack item");
+        assert(currentJob.workStack[i].start->getOperations().size() == 0 &&
+               "work stack block is not empty");
+
+        blockTransl.insert(
+            {currentJob.workStack[i].start, &region.emplaceBlock()});
+        newWorkStack[i].start = blockTransl[currentJob.workStack[i].start];
+      }
+
+      // Update all targets except the last one.
+      // The last one points to global success and thus must be kept.
+      for (size_t i = 1; i < currentJob.workStack.size(); i++) {
+        // This is guaranteed by the linked structure of the stack.
+        assert(blockTransl.count(currentJob.workStack[i].target) == 1 &&
+               "invalid successor for work stack item");
+
+        newWorkStack[i].target = blockTransl[currentJob.workStack[i].target];
+      }
+
+      // Find the next work item to compute after the branch constraint test
+      // succeeds.
+      Block *target = checkDesc.target;
+      if (blockTransl.count(checkDesc.target) == 1) {
+        target = blockTransl[checkDesc.target];
+      }
+
+      // Schedule checking the branch constraint itself.
+      newWorkStack.emplace_back(backtrackPoints[i - 1].toVisitWhenFails, target,
+                                argConstraints[i], checkDesc.typeToCheck);
+
+      // To summarize, at this point the new work stack consists of a copy of
+      // the initial work stack with a check for the constraint of this AnyOf
+      // branch on top. We can now add a job that will compile this work stack:
+      // first check that we indeed want to go deeper in this branch
+      // by compiling a check for this branch's constraint, then compile
+      // the rest of the work to do. If any of those things fails, we
+      // go to a backtrack point that points to a similar stack for the next
+      // AnyOf branch, or to the backtrack point of the current AnyOf.
+      this->compileJobs.emplace_back(std::move(newWorkStack),
+                                     std::move(backtrackPoints[i]),
+                                     currentJob.definedSlots);
+    }
+
+    // Reuse the original work stack for the first branch for efficiency
+    currentJob.workStack.emplace_back(checkDesc.start, checkDesc.target,
+                                      argConstraints[0], checkDesc.typeToCheck);
+    currentJob.btPoint = std::move(backtrackPoints[0]);
   }
 }
 
@@ -289,7 +358,7 @@ void ConstraintCompiler::compile(MLIRContext *ctx, Block &constraints,
                                  IRRewriter &rewriter, Location location,
                                  ArrayRef<Value> args) {
   rewriter.setInsertionPointToEnd(&constraints);
-  auto verifierOp = rewriter.create<Eval_Verifier>(location);
+  auto verifierOp = rewriter.create<Verifier>(location);
 
   Region &region = verifierOp.body();
 
@@ -300,7 +369,7 @@ void ConstraintCompiler::compile(MLIRContext *ctx, Block &constraints,
 
   if (args.size() == 0) {
     rewriter.setInsertionPointToStart(&start);
-    rewriter.create<Eval_Success>(location);
+    rewriter.create<Success>(location);
     return;
   }
 
@@ -308,19 +377,18 @@ void ConstraintCompiler::compile(MLIRContext *ctx, Block &constraints,
   DenseMap<Value, Value> cstrToSlot;
   for (Operation &op : constraints.getOperations()) {
     if (llvm::isa<VerifyConstraintInterface>(op)) {
-      Eval_Alloca alloca =
-          rewriter.create<Eval_Alloca>(location, SlotType::get(ctx));
+      Alloca alloca = rewriter.create<Alloca>(location, SlotType::get(ctx));
       cstrToSlot.insert({op.getResult(0), alloca.getResult()});
     }
   }
 
   Block &success = region.emplaceBlock();
   rewriter.setInsertionPointToStart(&success);
-  rewriter.create<Eval_Success>(location);
+  rewriter.create<Success>(location);
 
   Block &failure = region.emplaceBlock();
   rewriter.setInsertionPointToStart(&failure);
-  rewriter.create<Eval_Failure>(location);
+  rewriter.create<Failure>(location);
 
   ConstraintCompiler compiler(ctx, region, constraints, rewriter, location);
 
@@ -328,30 +396,16 @@ void ConstraintCompiler::compile(MLIRContext *ctx, Block &constraints,
   Block *workStart = &start;
   for (size_t i = 0; i < args.size() - 1; i++) {
     Block *workTarget = &region.emplaceBlock();
-    argToWork.push_back({
-        .start = workStart,
-        .target = workTarget,
-        .constraint = args[i],
-        .typeToCheck = start.getArgument(i),
-    });
+    argToWork.emplace_back(workStart, workTarget, args[i],
+                           start.getArgument(i));
     workStart = workTarget;
   }
-  argToWork.push_back({
-      .start = workStart,
-      .target = &success,
-      .constraint = args[args.size() - 1],
-      .typeToCheck = start.getArgument(args.size() - 1),
-  });
+  argToWork.emplace_back(workStart, &success, args[args.size() - 1],
+                         start.getArgument(args.size() - 1));
 
-  compiler.compileJobs.push_back({
-      .workStack = {argToWork.rbegin(), argToWork.rend()},
-      .btPoint =
-          {
-              .toVisitWhenFails = &failure,
-              .slotsToClearWhenFails = {},
-          },
-      .definedSlots = {},
-  });
+  compiler.compileJobs.emplace_back(
+      SmallVector<ConstraintCheck>(argToWork.rbegin(), argToWork.rend()),
+      BacktrackPoint(&failure));
 
   while (compiler.compileJobs.size() != 0) {
     assert(compiler.workStackInvariant() &&
@@ -401,20 +455,15 @@ void GenEval::runOnOperation() {
   SSA_DialectOp op = this->getOperation();
 
   op.walk([&](SSA_TypeOp op) {
-    for (Operation &child : op.getOps()) {
-      if (llvm::isa<Eval_Verifier>(child)) {
+    for (Operation &child : op.getOps())
+      if (llvm::isa<Verifier>(child))
         return;
-      }
-    }
 
     SmallVector<Value> args;
-    for (Operation &op : op.getRegion().getOps()) {
-      if (SSA_ParametersOp paramOp = llvm::dyn_cast<SSA_ParametersOp>(op)) {
-        for (auto arg : paramOp.args()) {
+    for (Operation &op : op.getRegion().getOps())
+      if (SSA_ParametersOp paramOp = llvm::dyn_cast<SSA_ParametersOp>(op))
+        for (auto arg : paramOp.args())
           args.push_back(arg);
-        }
-      }
-    }
 
     ConstraintCompiler::compile(&this->getContext(),
                                 op.body().getBlocks().front(), rewriter,
@@ -422,34 +471,20 @@ void GenEval::runOnOperation() {
   });
 
   op.walk([&](SSA_OperationOp op) {
-    for (Operation &child : op.getOps()) {
-      if (llvm::isa<Eval_Verifier>(child)) {
+    for (Operation &child : op.getOps())
+      if (llvm::isa<Verifier>(child))
         return;
-      }
-    }
 
-    SSA_OperandsOp operOp;
-    SSA_ResultsOp resOp;
-    for (Operation &op : op.getRegion().getOps()) {
-      if (SSA_OperandsOp opFound = llvm::dyn_cast<SSA_OperandsOp>(op)) {
-        operOp = opFound;
-      } else if (SSA_ResultsOp opFound = llvm::dyn_cast<SSA_ResultsOp>(op)) {
-        resOp = opFound;
-      }
-    }
+    Optional<SSA_OperandsOp> operOp = op.getOp<SSA_OperandsOp>();
+    Optional<SSA_ResultsOp> resOp = op.getOp<SSA_ResultsOp>();
 
     SmallVector<Value> args;
-    if (operOp) {
-      for (auto arg : operOp.args()) {
+    if (operOp)
+      for (auto arg : operOp->args())
         args.push_back(arg);
-      }
-    }
-
-    if (resOp) {
-      for (auto arg : resOp.args()) {
+    if (resOp)
+      for (auto arg : resOp->args())
         args.push_back(arg);
-      }
-    }
 
     ConstraintCompiler::compile(&this->getContext(),
                                 op.body().getBlocks().front(), rewriter,

--- a/dyn-opt/GenEval.h
+++ b/dyn-opt/GenEval.h
@@ -1,0 +1,37 @@
+//===- GenEval.h - Generates IRDL-Eval from IRDL-SSA ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Generates IRDL-Eval from IRDL-SSA definitions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYNOPT_GENEVAL_H
+#define DYNOPT_GENEVAL_H
+
+#include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSA.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace irdleval {
+
+class GenEval
+    : public mlir::PassWrapper<
+          GenEval, mlir::OperationPass<mlir::irdlssa::SSA_DialectOp>> {
+
+public:
+  void runOnOperation() override;
+
+  mlir::StringRef getArgument() const final { return "irdl-gen-eval"; }
+};
+
+} // namespace irdleval
+} // namespace mlir
+
+#endif // DYNOPT_GENEVAL_H

--- a/dyn-opt/dyn-opt.cpp
+++ b/dyn-opt/dyn-opt.cpp
@@ -6,8 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEval.h"
 #include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSA.h"
 #include "Dyn/Dialect/IRDL/IR/IRDL.h"
+#include "GenEval.h"
 #include "LowerIRDL.h"
 #include "MlirOptMain.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -32,6 +34,7 @@
 using namespace mlir;
 using namespace irdl;
 using namespace irdlssa;
+using namespace irdleval;
 
 class ComplexTypeWrapper : public ConcreteTypeWrapper<ComplexType> {
   StringRef getName() override { return "std.complex"; }
@@ -63,6 +66,8 @@ int main(int argc, char **argv) {
   ctx.getOrLoadDialect<irdl::IRDLDialect>();
   auto irdl = ctx.getOrLoadDialect<irdl::IRDLDialect>();
   auto irdlssa = ctx.getOrLoadDialect<irdlssa::IRDLSSADialect>();
+  ctx.getOrLoadDialect<irdleval::IRDLEvalDialect>();
+  ctx.getOrLoadDialect<mlir::cf::ControlFlowDialect>();
 
   irdlssa->addTypeWrapper<ComplexTypeWrapper>();
   irdl->addTypeWrapper<ComplexTypeWrapper>();
@@ -73,6 +78,10 @@ int main(int argc, char **argv) {
       [tyCtx{std::move(tyCtx)}]() -> std::unique_ptr<::mlir::Pass> {
         return std::make_unique<LowerIRDL>(tyCtx);
       });
+
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<GenEval>();
+  });
 
   // Register all dialects
   DialectRegistry registry;

--- a/dyn-opt/dyn-opt.cpp
+++ b/dyn-opt/dyn-opt.cpp
@@ -45,7 +45,7 @@ class ComplexTypeWrapper : public ConcreteTypeWrapper<ComplexType> {
 
   size_t getParameterAmount() override { return 1; }
 
-  Type instanciate(llvm::function_ref<InFlightDiagnostic()> emitError,
+  Type instantiate(llvm::function_ref<InFlightDiagnostic()> emitError,
                    ArrayRef<Attribute> parameters) override {
     if (parameters.size() != this->getParameterAmount()) {
       emitError().append("invalid number of type parameters ",

--- a/include/Dyn/Dialect/CMakeLists.txt
+++ b/include/Dyn/Dialect/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(IRDL)
 add_subdirectory(IRDL-SSA)
+add_subdirectory(IRDL-Eval)

--- a/include/Dyn/Dialect/IRDL-Eval/CMakeLists.txt
+++ b/include/Dyn/Dialect/IRDL-Eval/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/include/Dyn/Dialect/IRDL-Eval/IR/CMakeLists.txt
+++ b/include/Dyn/Dialect/IRDL-Eval/IR/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_mlir_dialect(IRDLEval irdleval)
+
+# Add IRDL-Eval operations
+set(LLVM_TARGET_DEFINITIONS IRDLEvalOps.td)
+mlir_tablegen(IRDLEvalOps.h.inc -gen-op-decls)
+mlir_tablegen(IRDLEvalOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRIRDLEvalOpsIncGen)
+add_dependencies(mlir-generic-headers MLIRIRDLEvalOpsIncGen)
+
+# Add IRDL-Eval types
+set(LLVM_TARGET_DEFINITIONS IRDLEvalTypes.td)
+mlir_tablegen(IRDLEvalTypesGen.h.inc -gen-typedef-decls) # TODO: Explain why this requires a different name
+mlir_tablegen(IRDLEvalTypesGen.cpp.inc -gen-typedef-defs)
+add_public_tablegen_target(MLIRIRDLEvalTypesIncGen)
+add_dependencies(mlir-generic-headers MLIRIRDLEvalTypesIncGen)

--- a/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEval.h
+++ b/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEval.h
@@ -1,0 +1,35 @@
+//===- IRDLEval.h - IRDL-Eval Definition ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines IRDL-Eval IR constructs.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DIALECT_IRDL_EVAL_IR_IRDL_EVAL_H_
+#define DYN_DIALECT_IRDL_EVAL_IR_IRDL_EVAL_H_
+
+#include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSA.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/ExtensibleDialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEvalDialect.h.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEvalTypesGen.h.inc"
+
+#define GET_OP_CLASSES
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.h.inc"
+
+#endif // DYN_DIALECT_IRDL_EVAL_IR_IRDL_EVAL_H_

--- a/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEval.td
+++ b/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEval.td
@@ -15,7 +15,7 @@
 
 include "mlir/IR/OpBase.td"
 
-def IRDL_Eval_Dialect : Dialect {
+def IRDLEval_Dialect : Dialect {
   let summary = "IR Definition Language Eval Dialect";
   let description = [{
       IRDL-Eval is a dialect to represent automata checking type constraints.

--- a/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEval.td
+++ b/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEval.td
@@ -1,0 +1,78 @@
+//===- IRDLEval.td - IRDL-Eval Dialect ---------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the IRDL-Eval dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DIALECT_IRDL_EVAL_IR_IRDL_EVAL
+#define DYN_DIALECT_IRDL_EVAL_IR_IRDL_EVAL
+
+include "mlir/IR/OpBase.td"
+
+def IRDL_Eval_Dialect : Dialect {
+  let summary = "IR Definition Language Eval Dialect";
+  let description = [{
+      IRDL-Eval is a dialect to represent automata checking type constraints.
+      These automata are expressed using concepts close to LLVM IR, so that
+      it is easy to lower to assembly.
+
+      Verifying automata can be appended to IRDL-SSA definitions by inserting
+      `irdleval.verifier` operations within `irdlssa.type` or
+      `irdlssa.operation` operations. The verifier operation itself then
+      describes an automata that should be equivalent to checking the sibling
+      constraint declarations.
+
+      The automata operate on type variables (SSA values of type
+      `irdleval.eval_type`). IRDL-Eval operations are sequential type checking
+      primitives. Additionally, IRDL-Eval provides a global type slot table
+      that allows mapping type slots (allocated via `irdleval.alloca`) to
+      concrete types. See instruction documentation for more details.
+
+      Example:
+
+      ```
+      irdlssa.operation add_float {
+        %0 = irdlssa.is_type : f32
+        %1 = irdlssa.is_type : f64
+        %2 = irdlssa.any_of(%0, %1)
+        irdlssa.operands(%2, %2)
+        irdlssa.results(%2)
+        
+        irdleval.verifier {
+        ^bb0(%oper0: !irdleval.eval_type, %oper1: !irdleval.eval_type, %res: !irdleval.eval_type):
+          %3 = irdleval.alloca
+          irdleval.check_type(%oper0, f32, ^bb3, ^bb1)
+        ^bb1:
+          irdleval.check_type(%oper0, f64, ^bb3, ^bb2)
+        ^bb2:
+          irdleval.failure
+        ^bb3:
+          irdleval.assign(%3, %oper0)
+          irdleval.match_type(%3, %oper1, ^bb4, ^bb2)
+        ^bb4:
+          irdleval.match_type(%3, %res, ^bb5, ^bb2)
+        ^bb5:
+          irdleval.success
+        }
+      }
+      ```
+
+      This verifier implementation is equivalent to its sibling constraints:
+      it checks that the first operand is either `f32` or `f64`, then ensures
+      that the second operand type and the result type are equal to the first
+      operand type.
+  }];
+
+  let useDefaultTypePrinterParser = 1;
+
+  let name = "irdleval";
+  let cppNamespace = "::mlir::irdleval";
+}
+
+#endif // DYN_DIALECT_IRDL_EVAL_IR_IRDL_EVAL

--- a/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.td
+++ b/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.td
@@ -1,0 +1,359 @@
+//===- IRDLEvalOps.td - IR Definition Language Dialect ------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the IRDL-Eval dialect ops.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DIALECT_IRDL_EVAL_IR_IRDLEVALOPS
+#define DYN_DIALECT_IRDL_EVAL_IR_IRDLEVALOPS
+
+include "IRDLEval.td"
+include "IRDLEvalTypes.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.td"
+
+class IRDL_Eval_Op<string mnemonic, list<Trait> traits = []>
+    : Op<IRDL_Eval_Dialect, mnemonic, traits> {
+}
+
+def IRDL_Eval_Verifier : IRDL_Eval_Op<"verifier", [ParentOneOf<["mlir::irdlssa::SSA_TypeOp", "mlir::irdlssa::SSA_OperationOp"]>]> {
+  let summary = "Defines the verification procedure associated to this op";
+  let description = [{
+    `irdleval.verifier` represents a specific type-checking automata.
+    This instruction is to be inserted within `irdlssa.type` or
+    `irdlssa.operation` operations. The automata described by
+    `irdleval.verifier` must perform verification equivalent to its
+    sibling constraints.
+
+    Its region contains the automata description. The entry block takes
+    as parameter the types that are to be checked. If control-flow reaches
+    an `irdleval.success` operation, all type checking constraints are
+    satisfied. If control-flow reaches an `irdleval.failure` operation, the
+    whole type checking operation fails.
+
+    In the case of `irdlssa.operation`, the first arguments to the entry
+    block are operands, followed by results.
+
+    Example:
+
+    ```
+    irdlssa.operation add_float {
+      %0 = irdlssa.is_type : f32
+      %1 = irdlssa.is_type : f64
+      %2 = irdlssa.any_of(%0, %1)
+      irdlssa.operands(%2, %2)
+      irdlssa.results(%2)
+      
+      irdleval.verifier {
+      ^bb0(%oper0: !irdleval.eval_type, %oper1: !irdleval.eval_type, %res: !irdleval.eval_type):
+        %3 = irdleval.alloca
+        irdleval.check_type(%oper0, f32, ^bb3, ^bb1)
+      ^bb1:
+        irdleval.check_type(%oper0, f64, ^bb3, ^bb2)
+      ^bb2:
+        irdleval.failure
+      ^bb3:
+        irdleval.assign(%3, %oper0)
+        irdleval.match_type(%3, %oper1, ^bb4, ^bb2)
+      ^bb4:
+        irdleval.match_type(%3, %res, ^bb5, ^bb2)
+      ^bb5:
+        irdleval.success
+      }
+    }
+    ```
+
+    This verifier implementation is equivalent to its sibling constraints:
+    it checks that the first operand is either `f32` or `f64`, then ensures
+    that the second operand type and the result type are equal to the first
+    operand type.
+  }];
+
+  let regions = (region AnyRegion:$body);
+  let assemblyFormat = "$body attr-dict";
+  let hasVerifier = 1;
+}
+
+def IRDL_Eval_Goto : IRDL_Eval_Op<"goto", [Terminator]> {
+  let summary = "Goes to a block";
+  let description = [{
+    `irdleval.goto` redirects control-flow to the specified block.
+
+    Example:
+
+    ```
+    irdleval.verifier {
+    ^bb0:
+      irdleval.goto(^bb1)
+    ^bb1:
+      irdleval.success
+    ```
+
+    This verifier first jumps to `^bb1`, then suceeds.
+  }];
+
+  let arguments = (ins);
+  let successors = (successor AnySuccessor:$to);
+  let assemblyFormat = [{ `(` $to `)` attr-dict }];
+  let hasVerifier = 1;
+}
+
+def IRDL_Eval_Success : IRDL_Eval_Op<"success", [Terminator, ReturnLike]> {
+  let summary = "Marks the verification as successful";
+  let description = [{
+    `irdleval.success` marks successful verification for the entire
+    verification checking instrance. If it is reached, the current
+    verification is considered successful and execution halts.
+
+    Example:
+
+    ```
+    irdleval.verifier {
+    ^bb0:
+      irdleval.success
+    }
+    ```
+
+    This verifier succeeds immediately.
+  }];
+
+  let arguments = (ins);
+  let assemblyFormat = [{ attr-dict }];
+}
+
+def IRDL_Eval_Failure : IRDL_Eval_Op<"failure", [Terminator, ReturnLike]> {
+  let summary = "Marks the verification as failed";
+  let description = [{
+    `irdleval.failure` marks verification failure for the entire
+    verification checking instrance. If it is reached, the current
+    verification is considered failed and execution halts.
+
+    Example:
+
+    ```
+    irdleval.verifier {
+    ^bb0:
+      irdleval.failure
+    }
+    ```
+
+    This verifier fails immediately.
+  }];
+
+  let arguments = (ins);
+  let assemblyFormat = [{ attr-dict }];
+}
+
+def IRDL_Eval_CheckType : IRDL_Eval_Op<"check_type", [Terminator]> {
+  let summary = "Checks whether the provided type is equal to the specified type";
+  let description = [{
+    `irdleval.check_type` checks whether the
+    type contained in the provided variable matches the type
+    described by the associated (potentially parametric) type
+    attribute.
+
+    The type attribute must represent a concrete type instance,
+    and notably cannot represent types parameterized by other
+    type variables. For such use case, see `irdleval.check_parametric`.
+
+    Example:
+
+    ```
+    irdleval.verifier {
+    ^bb0(%arg: !irdleval.eval_type):
+      irdleval.check_type(%arg, "cmath.complex"<f32>, ^bb1, ^bb2)
+    ^bb1:
+      irdleval.success
+    ^bb2:
+      irdleval.failure
+    }
+    ```
+
+    This verifier checks that the `%arg` type variable contains
+    the type `cmath.complex<f32>`, failing otherwise.
+  }];
+
+  let arguments = (ins IRDL_Eval_EvalType:$typeVar, ParamTypeAttrOrAnyAttr:$expected);
+  let successors = (successor AnySuccessor:$success, AnySuccessor:$failure);
+  let assemblyFormat = [{ `(` $typeVar `,` $expected `,` $success `,` $failure `)` attr-dict }];
+  let hasVerifier = 1;
+}
+
+def IRDL_Eval_CheckParametric : IRDL_Eval_Op<"check_parametric", [Terminator]> {
+  let summary = "Checks whether a type's base type corresponds to the expected type";
+  let description = [{
+    `irdleval.check_type` checks whether the
+    type contained in the provided variable matches the parametric
+    structure of the type described by the associated base identifier.
+
+    Control-flow jumps:
+    - to the `invalidBase` block if the base type does not match, and
+    - to the `success` block if the base type matches. The parametric types
+      are in that case passed as arguments to the `success` block, which must as
+      such have the same amount of arguments as there are type parameters.
+    
+    Example:
+
+    ```
+    irdleval.verifier {
+    ^bb0(%arg: !irdleval.eval_type):
+      irdleval.check_type(%arg, "cmath.complex", ^bb1, ^bb2)
+    ^bb1:
+      irdleval.success
+    ^bb2:
+      irdleval.failure
+    }
+    ```
+
+    This verifier checks that the argument type is an instance of `cmath.complex`,
+    but does not check anything with respect to the validity of its type parameters.
+  }];
+
+  let arguments = (ins IRDL_Eval_EvalType:$typeVar, StrAttr:$base);
+  let successors = (successor AnySuccessor:$success, AnySuccessor:$invalidBase);
+  let assemblyFormat = [{ `(` $typeVar `,` $base `,` $success `,` $invalidBase `)` attr-dict }];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// IRDL-Eval Slot operations
+//===----------------------------------------------------------------------===//
+
+def IRDL_Eval_MatchType : IRDL_Eval_Op<"match_type", [Terminator]> {
+  let summary = "Checks whether a type matches the type assigned to a constraint identifier";
+  let description = [{
+    `irdleval.match_type` checks that the provided slots contains
+    the same type as what the provided type variable contains.
+
+    Matching against an empty slot is undefined behavior.
+
+    Example:
+
+    ```
+    irdleval.verifier {
+    ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+      %0 = irdleval.alloca
+      irdleval.assign(%0, %arg0)
+      irdleval.match_type(%0, %arg1, ^bb1, ^bb2)
+    ^bb1:
+      irdleval.success
+    ^bb2:
+      irdleval.failure
+    }
+    ```
+
+    This verifier verifies `%arg0` and `%arg1` contains the same
+    types. It allocates a slot in the slot table, then assigns the type
+    in `%arg0` to the slot. Then, the slot type value is compared to
+    the type in `%arg1`, failing if they are not equal.
+  }];
+
+  let arguments = (ins IRDL_Eval_SlotType:$slot, IRDL_Eval_EvalType:$typeVar);
+  let successors = (successor AnySuccessor:$success, AnySuccessor:$failure);
+  let assemblyFormat = [{ `(` $slot `,` $typeVar `,` $success `,` $failure `)` attr-dict }];
+  let hasVerifier = 1;
+}
+
+def IRDL_Eval_AssignType : IRDL_Eval_Op<"assign"> {
+  let summary = "Assigns a type to a constraint identifier";
+  let description = [{
+    `irdleval.assign` assigns a type to a slot in the slot
+    table.
+
+    Example:
+
+    ```
+    irdleval.verifier {
+    ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+      %0 = irdleval.alloca
+      irdleval.assign(%0, %arg0)
+      irdleval.match_type(%0, %arg1, ^bb1, ^bb2)
+    ^bb1:
+      irdleval.success
+    ^bb2:
+      irdleval.failure
+    }
+    ```
+
+    This verifier verifies `%arg0` and `%arg1` contains the same
+    types. It allocates a slot `%0` in the slot table, then assigns the type
+    in `%arg0` to the slot. Then, the slot type value is compared to
+    the type in `%arg1`, failing if they are not equal.
+  }];
+
+  let arguments = (ins IRDL_Eval_SlotType:$slot, IRDL_Eval_EvalType:$typeVar);
+  let assemblyFormat = [{ `(` $slot `,` $typeVar `)` attr-dict }];
+}
+
+def IRDL_Eval_ClearType : IRDL_Eval_Op<"clear"> {
+  let summary = "Clears the type associated to a constraint variable";
+  let description = [{
+    `irdleval.clear` clears the content of a slot. This is notably useful
+    for backtracking, to revert constraint type assignments for example.
+
+    Example:
+    irdleval.verifier {
+    ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type, %arg2: !irdleval.eval_type):
+      %0 = irdleval.alloca
+      irdleval.assign(%0, %arg0)
+      irdleval.match_type(%0, %arg2, ^bb1, ^bb2)
+    ^bb1:
+      irdleval.success
+    ^bb2:
+      irdleval.clear(%0)
+      irdleval.assign(%0, %arg1)
+      irdleval.match_type(%0, %arg2, ^bb1, ^bb3)
+    ^bb3:
+      irdleval.failure
+    }
+    ```
+
+    This verifier checks that `%arg2` contains the same type as `%arg0` or `%arg1`. It does
+    so by assigning the type in `%arg0` in slot `%0`, checking slot `%0` against `%arg2`.
+    If this fails, it clears slot `%0` and tries again with the type in `%arg1`.
+  }];
+
+  let arguments = (ins IRDL_Eval_SlotType:$slot);
+  let assemblyFormat = [{ `(` $slot `)` attr-dict }];
+}
+
+def IRDL_Eval_Alloca : IRDL_Eval_Op<"alloca"> {
+  let summary = "Allocates a slot to store types";
+  let description = [{
+    `irdleval.alloca` allocates a slot in the slot table for use.
+
+    Example:
+
+    ```
+    irdleval.verifier {
+    ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+      %0 = irdleval.alloca
+      irdleval.assign(%0, %arg0)
+      irdleval.match_type(%0, %arg1, ^bb1, ^bb2)
+    ^bb1:
+      irdleval.success
+    ^bb2:
+      irdleval.failure
+    }
+    ```
+
+    This verifier verifies `%arg0` and `%arg1` contains the same
+    types. It allocates a slot `%0` in the slot table, then assigns the type
+    in `%arg0` to the slot. Then, the slot type value is compared to
+    the type in `%arg1`, failing if they are not equal.
+  }];
+
+  let arguments = (ins);
+  let results = (outs IRDL_Eval_SlotType:$output);
+  let assemblyFormat = [{ attr-dict }];
+}
+
+#endif // DYN_DIALECT_IRDL_EVAL_IR_IRDLEVALOPS

--- a/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.td
+++ b/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.td
@@ -1,4 +1,4 @@
-//===- IRDLEvalOps.td - IR Definition Language Dialect ------*- tablegen -*-===//
+//===- IRDLEvalOps.td - IRDL Eval Dialect ------------------*- tablegen -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -20,11 +20,11 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/BuiltinAttributes.td"
 include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.td"
 
-class IRDL_Eval_Op<string mnemonic, list<Trait> traits = []>
-    : Op<IRDL_Eval_Dialect, mnemonic, traits> {
+class IRDLEval_Op<string mnemonic, list<Trait> traits = []>
+    : Op<IRDLEval_Dialect, mnemonic, traits> {
 }
 
-def IRDL_Eval_Verifier : IRDL_Eval_Op<"verifier", [ParentOneOf<["mlir::irdlssa::SSA_TypeOp", "mlir::irdlssa::SSA_OperationOp"]>]> {
+def IRDLEval_Verifier : IRDLEval_Op<"verifier", [ParentOneOf<["mlir::irdlssa::SSA_TypeOp", "mlir::irdlssa::SSA_OperationOp"]>]> {
   let summary = "Defines the verification procedure associated to this op";
   let description = [{
     `irdleval.verifier` represents a specific type-checking automata.
@@ -82,31 +82,7 @@ def IRDL_Eval_Verifier : IRDL_Eval_Op<"verifier", [ParentOneOf<["mlir::irdlssa::
   let hasVerifier = 1;
 }
 
-def IRDL_Eval_Goto : IRDL_Eval_Op<"goto", [Terminator]> {
-  let summary = "Goes to a block";
-  let description = [{
-    `irdleval.goto` redirects control-flow to the specified block.
-
-    Example:
-
-    ```
-    irdleval.verifier {
-    ^bb0:
-      irdleval.goto(^bb1)
-    ^bb1:
-      irdleval.success
-    ```
-
-    This verifier first jumps to `^bb1`, then suceeds.
-  }];
-
-  let arguments = (ins);
-  let successors = (successor AnySuccessor:$to);
-  let assemblyFormat = [{ `(` $to `)` attr-dict }];
-  let hasVerifier = 1;
-}
-
-def IRDL_Eval_Success : IRDL_Eval_Op<"success", [Terminator, ReturnLike]> {
+def IRDLEval_Success : IRDLEval_Op<"success", [Terminator, ReturnLike]> {
   let summary = "Marks the verification as successful";
   let description = [{
     `irdleval.success` marks successful verification for the entire
@@ -129,7 +105,7 @@ def IRDL_Eval_Success : IRDL_Eval_Op<"success", [Terminator, ReturnLike]> {
   let assemblyFormat = [{ attr-dict }];
 }
 
-def IRDL_Eval_Failure : IRDL_Eval_Op<"failure", [Terminator, ReturnLike]> {
+def IRDLEval_Failure : IRDLEval_Op<"failure", [Terminator, ReturnLike]> {
   let summary = "Marks the verification as failed";
   let description = [{
     `irdleval.failure` marks verification failure for the entire
@@ -152,7 +128,7 @@ def IRDL_Eval_Failure : IRDL_Eval_Op<"failure", [Terminator, ReturnLike]> {
   let assemblyFormat = [{ attr-dict }];
 }
 
-def IRDL_Eval_CheckType : IRDL_Eval_Op<"check_type", [Terminator]> {
+def IRDLEval_CheckType : IRDLEval_Op<"check_type", [Terminator]> {
   let summary = "Checks whether the provided type is equal to the specified type";
   let description = [{
     `irdleval.check_type` checks whether the
@@ -181,16 +157,16 @@ def IRDL_Eval_CheckType : IRDL_Eval_Op<"check_type", [Terminator]> {
     the type `cmath.complex<f32>`, failing otherwise.
   }];
 
-  let arguments = (ins IRDL_Eval_EvalType:$typeVar, ParamTypeAttrOrAnyAttr:$expected);
+  let arguments = (ins IRDLEval_EvalType:$typeVar, ParamTypeAttrOrAnyAttr:$expected);
   let successors = (successor AnySuccessor:$success, AnySuccessor:$failure);
   let assemblyFormat = [{ `(` $typeVar `,` $expected `,` $success `,` $failure `)` attr-dict }];
   let hasVerifier = 1;
 }
 
-def IRDL_Eval_CheckParametric : IRDL_Eval_Op<"check_parametric", [Terminator]> {
+def IRDLEval_CheckParametric : IRDLEval_Op<"check_parametric", [Terminator]> {
   let summary = "Checks whether a type's base type corresponds to the expected type";
   let description = [{
-    `irdleval.check_type` checks whether the
+    `irdleval.check_parametric` checks whether the
     type contained in the provided variable matches the parametric
     structure of the type described by the associated base identifier.
 
@@ -205,7 +181,7 @@ def IRDL_Eval_CheckParametric : IRDL_Eval_Op<"check_parametric", [Terminator]> {
     ```
     irdleval.verifier {
     ^bb0(%arg: !irdleval.eval_type):
-      irdleval.check_type(%arg, "cmath.complex", ^bb1, ^bb2)
+      irdleval.check_parametric(%arg, "cmath.complex", ^bb1, ^bb2)
     ^bb1:
       irdleval.success
     ^bb2:
@@ -217,7 +193,7 @@ def IRDL_Eval_CheckParametric : IRDL_Eval_Op<"check_parametric", [Terminator]> {
     but does not check anything with respect to the validity of its type parameters.
   }];
 
-  let arguments = (ins IRDL_Eval_EvalType:$typeVar, StrAttr:$base);
+  let arguments = (ins IRDLEval_EvalType:$typeVar, StrAttr:$base);
   let successors = (successor AnySuccessor:$success, AnySuccessor:$invalidBase);
   let assemblyFormat = [{ `(` $typeVar `,` $base `,` $success `,` $invalidBase `)` attr-dict }];
   let hasVerifier = 1;
@@ -227,7 +203,7 @@ def IRDL_Eval_CheckParametric : IRDL_Eval_Op<"check_parametric", [Terminator]> {
 // IRDL-Eval Slot operations
 //===----------------------------------------------------------------------===//
 
-def IRDL_Eval_MatchType : IRDL_Eval_Op<"match_type", [Terminator]> {
+def IRDLEval_MatchType : IRDLEval_Op<"match_type", [Terminator]> {
   let summary = "Checks whether a type matches the type assigned to a constraint identifier";
   let description = [{
     `irdleval.match_type` checks that the provided slots contains
@@ -256,13 +232,13 @@ def IRDL_Eval_MatchType : IRDL_Eval_Op<"match_type", [Terminator]> {
     the type in `%arg1`, failing if they are not equal.
   }];
 
-  let arguments = (ins IRDL_Eval_SlotType:$slot, IRDL_Eval_EvalType:$typeVar);
+  let arguments = (ins IRDLEval_SlotType:$slot, IRDLEval_EvalType:$typeVar);
   let successors = (successor AnySuccessor:$success, AnySuccessor:$failure);
   let assemblyFormat = [{ `(` $slot `,` $typeVar `,` $success `,` $failure `)` attr-dict }];
   let hasVerifier = 1;
 }
 
-def IRDL_Eval_AssignType : IRDL_Eval_Op<"assign"> {
+def IRDLEval_AssignType : IRDLEval_Op<"assign"> {
   let summary = "Assigns a type to a constraint identifier";
   let description = [{
     `irdleval.assign` assigns a type to a slot in the slot
@@ -289,11 +265,11 @@ def IRDL_Eval_AssignType : IRDL_Eval_Op<"assign"> {
     the type in `%arg1`, failing if they are not equal.
   }];
 
-  let arguments = (ins IRDL_Eval_SlotType:$slot, IRDL_Eval_EvalType:$typeVar);
+  let arguments = (ins IRDLEval_SlotType:$slot, IRDLEval_EvalType:$typeVar);
   let assemblyFormat = [{ `(` $slot `,` $typeVar `)` attr-dict }];
 }
 
-def IRDL_Eval_ClearType : IRDL_Eval_Op<"clear"> {
+def IRDLEval_ClearType : IRDLEval_Op<"clear"> {
   let summary = "Clears the type associated to a constraint variable";
   let description = [{
     `irdleval.clear` clears the content of a slot. This is notably useful
@@ -321,11 +297,11 @@ def IRDL_Eval_ClearType : IRDL_Eval_Op<"clear"> {
     If this fails, it clears slot `%0` and tries again with the type in `%arg1`.
   }];
 
-  let arguments = (ins IRDL_Eval_SlotType:$slot);
+  let arguments = (ins IRDLEval_SlotType:$slot);
   let assemblyFormat = [{ `(` $slot `)` attr-dict }];
 }
 
-def IRDL_Eval_Alloca : IRDL_Eval_Op<"alloca"> {
+def IRDLEval_Alloca : IRDLEval_Op<"alloca"> {
   let summary = "Allocates a slot to store types";
   let description = [{
     `irdleval.alloca` allocates a slot in the slot table for use.
@@ -352,7 +328,7 @@ def IRDL_Eval_Alloca : IRDL_Eval_Op<"alloca"> {
   }];
 
   let arguments = (ins);
-  let results = (outs IRDL_Eval_SlotType:$output);
+  let results = (outs IRDLEval_SlotType:$output);
   let assemblyFormat = [{ attr-dict }];
 }
 

--- a/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalTypes.td
+++ b/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalTypes.td
@@ -1,0 +1,40 @@
+//===- IRDLEvalTypes.td - IRDL-Eval Types ------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the types IRDL-SSA uses.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DIALECT_IRDL_EVAL_IR_IRDLEVALTYPES
+#define DYN_DIALECT_IRDL_EVAL_IR_IRDLEVALTYPES
+
+include "mlir/IR/AttrTypeBase.td"
+include "IRDLEval.td"
+
+class IRDL_Eval_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<IRDL_Eval_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+def IRDL_Eval_EvalType : IRDL_Eval_Type<"EvalType", "eval_type"> {
+  let summary = "Type representing a type";
+  let description = [{
+    `irdleval.eval_type` is the type of types when stored
+    in SSA values.
+  }];
+}
+
+def IRDL_Eval_SlotType : IRDL_Eval_Type<"Slot", "slot"> {
+  let summary = "Type representing a slot to hold a type mapped to a constraint";
+  let description = [{
+    `irdleval.slot` is the type of slots once allocated with
+    `irdleval.alloca`.
+  }];
+}
+
+#endif // DYN_DIALECT_IRDL_EVAL_IR_IRDLEVALTYPES

--- a/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalTypes.td
+++ b/include/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalTypes.td
@@ -16,12 +16,12 @@
 include "mlir/IR/AttrTypeBase.td"
 include "IRDLEval.td"
 
-class IRDL_Eval_Type<string name, string typeMnemonic, list<Trait> traits = []>
-    : TypeDef<IRDL_Eval_Dialect, name, traits> {
+class IRDLEval_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<IRDLEval_Dialect, name, traits> {
   let mnemonic = typeMnemonic;
 }
 
-def IRDL_Eval_EvalType : IRDL_Eval_Type<"EvalType", "eval_type"> {
+def IRDLEval_EvalType : IRDLEval_Type<"EvalType", "type"> {
   let summary = "Type representing a type";
   let description = [{
     `irdleval.eval_type` is the type of types when stored
@@ -29,7 +29,7 @@ def IRDL_Eval_EvalType : IRDL_Eval_Type<"EvalType", "eval_type"> {
   }];
 }
 
-def IRDL_Eval_SlotType : IRDL_Eval_Type<"Slot", "slot"> {
+def IRDLEval_SlotType : IRDLEval_Type<"Slot", "slot"> {
   let summary = "Type representing a slot to hold a type mapped to a constraint";
   let description = [{
     `irdleval.slot` is the type of slots once allocated with

--- a/include/Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.h
+++ b/include/Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.h
@@ -21,21 +21,20 @@
 namespace mlir {
 namespace irdleval {
 
-struct IRDLEvalInterpreter {
+class IRDLEvalInterpreter {
+  IRDLEvalInterpreter() {}
+
+public:
   struct ExecutionResult {
     bool completed;
     bool succeeded;
 
-    static ExecutionResult progress() { return {.completed = false}; }
-    static ExecutionResult success() {
-      return {.completed = true, .succeeded = true};
-    }
-    static ExecutionResult failure() {
-      return {.completed = true, .succeeded = false};
-    }
+    static ExecutionResult progress() { return {false, false}; }
+    static ExecutionResult success() { return {true, true}; }
+    static ExecutionResult failure() { return {true, false}; }
   };
 
-  struct Verifier {
+  struct InterpreterVerifier {
     IRDLEvalInterpreter const &interpreter;
 
     size_t currentBlock;
@@ -48,13 +47,15 @@ struct IRDLEvalInterpreter {
   };
 
   struct Instruction {
-    virtual ExecutionResult interpret(Verifier &verifier) = 0;
+    virtual ExecutionResult interpret(InterpreterVerifier &verifier) = 0;
   };
 
-  LogicalResult compile(llvm::function_ref<InFlightDiagnostic()> emitError,
-                        MLIRContext *ctx, Eval_Verifier op);
-  Verifier getVerifier() const;
+  static Optional<IRDLEvalInterpreter>
+  compile(llvm::function_ref<InFlightDiagnostic()> emitError, MLIRContext *ctx,
+          Verifier op);
+  InterpreterVerifier getVerifier() const;
 
+private:
   DenseMap<size_t, SmallVector<std::unique_ptr<Instruction>>> program;
   SmallVector<size_t> argTypeVariables;
 };

--- a/include/Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.h
+++ b/include/Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.h
@@ -1,0 +1,65 @@
+//===- IRDLEvalInterpreter.h ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Interpreter for IRDL-Eval, useful for testing purposes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYN_DIALECT_IRDL_EVAL_IRDL_EVAL_INTERPRETER_H_
+#define DYN_DIALECT_IRDL_EVAL_IRDL_EVAL_INTERPRETER_H_
+
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEval.h"
+#include "mlir/IR/Types.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace irdleval {
+
+struct IRDLEvalInterpreter {
+  struct ExecutionResult {
+    bool completed;
+    bool succeeded;
+
+    static ExecutionResult progress() { return {.completed = false}; }
+    static ExecutionResult success() {
+      return {.completed = true, .succeeded = true};
+    }
+    static ExecutionResult failure() {
+      return {.completed = true, .succeeded = false};
+    }
+  };
+
+  struct Verifier {
+    IRDLEvalInterpreter const &interpreter;
+
+    size_t currentBlock;
+    size_t instructionPointer;
+    DenseMap<size_t, mlir::Type> slotTable;
+    DenseMap<size_t, mlir::Type> typeVariables;
+
+    LogicalResult verify(llvm::function_ref<InFlightDiagnostic()> emitError,
+                         ArrayRef<Type> args);
+  };
+
+  struct Instruction {
+    virtual ExecutionResult interpret(Verifier &verifier) = 0;
+  };
+
+  LogicalResult compile(llvm::function_ref<InFlightDiagnostic()> emitError,
+                        MLIRContext *ctx, Eval_Verifier op);
+  Verifier getVerifier() const;
+
+  DenseMap<size_t, SmallVector<std::unique_ptr<Instruction>>> program;
+  SmallVector<size_t> argTypeVariables;
+};
+
+} // namespace irdleval
+} // namespace mlir
+
+#endif // DYN_DIALECT_IRDL_EVAL_IRDL_EVAL_INTERPRETER_H_

--- a/include/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.td
+++ b/include/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.td
@@ -42,7 +42,7 @@ def ParamTypeAttrOrAnyAttr : IRDL_SSA_AttrDef<"ParamTypeAttrOrAny", "param_type_
 
   let extraClassDeclaration = [{
     public:
-    Attribute instanciateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,
+    Attribute instantiateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,
                                    MLIRContext &ctx);
   }];
 }

--- a/include/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.td
+++ b/include/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.td
@@ -15,7 +15,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
-include "IRDLSSA.td"
+include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSA.td"
 
 class IRDL_SSA_AttrDef<string name, string attrMnemonic, list<Trait> traits = []>
   : AttrDef<IRDL_SSA_Dialect, name, traits, "::mlir::Attribute"> {
@@ -39,6 +39,12 @@ def ParamTypeAttrOrAnyAttr : IRDL_SSA_AttrDef<"ParamTypeAttrOrAny", "param_type_
   }];
   let parameters = (ins "::mlir::Attribute":$attr);
   let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    public:
+    Attribute instanciateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,
+                                   MLIRContext &ctx);
+  }];
 }
 
 #endif // DYN_DIALECT_IRDL_SSA_IR_IRDLSSAATTRIBUTES

--- a/include/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAOps.td
+++ b/include/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAOps.td
@@ -240,7 +240,7 @@ def IRDL_SSA_IsType : IRDL_SSA_ConstraintOp<"is_type", [ParentOneOf<["SSA_TypeOp
     The above program defines a type `complex_restrictive` inside the dialect `cmath` that
     can only have `i32` as its parameter.
 
-    `irdlssa.is_type` also accepts completely instanciated parametric types,
+    `irdlssa.is_type` also accepts completely instantiated parametric types,
     such as `std.complex<f32>`. It does not however allow expressing asbtract
     types, such as `std.complex<T>` where `T` is a type constraint. See
     `irdlssa.parametric_type` instead for this use case.
@@ -268,7 +268,7 @@ def IRDL_SSA_IsType : IRDL_SSA_ConstraintOp<"is_type", [ParentOneOf<["SSA_TypeOp
 }
 
 def IRDL_SSA_ParametricType : IRDL_SSA_ConstraintOp<"parametric_type", [ParentOneOf<["SSA_TypeOp", "SSA_OperationOp"]>, NoSideEffect]> {
-  let summary = "Constraints to a specific instanciated type";
+  let summary = "Constraints to a specific instantiated type";
   let description = [{
     `irdlssa.parametric_type` defines a constraint that accepts either a type defined
     in IRDL-SSA or a type wrapper. If the requested type is parametric, it will

--- a/include/Dyn/Dialect/IRDL/TypeWrapper.h
+++ b/include/Dyn/Dialect/IRDL/TypeWrapper.h
@@ -57,6 +57,9 @@ public:
   bool isCorrectType(mlir::Type type) override { return type.isa<T>(); }
 };
 
+DynamicTypeDefinition *findDynamicType(MLIRContext &ctx, StringRef type);
+TypeWrapper *findTypeWrapper(MLIRContext &ctx, StringRef type);
+
 } // namespace irdl
 } // namespace mlir
 

--- a/include/Dyn/Dialect/IRDL/TypeWrapper.h
+++ b/include/Dyn/Dialect/IRDL/TypeWrapper.h
@@ -37,7 +37,7 @@ public:
   virtual llvm::StringRef getName() = 0;
 
   /// Instanciates the type from parameters.
-  virtual Type instanciate(llvm::function_ref<InFlightDiagnostic()> emitError,
+  virtual Type instantiate(llvm::function_ref<InFlightDiagnostic()> emitError,
                            llvm::ArrayRef<Attribute> parameters) = 0;
 
   /// Returns the amount of parameters the type expects.

--- a/lib/Dyn/Dialect/CMakeLists.txt
+++ b/lib/Dyn/Dialect/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(IRDL)
 add_subdirectory(IRDL-SSA)
+add_subdirectory(IRDL-Eval)

--- a/lib/Dyn/Dialect/IRDL-Eval/CMakeLists.txt
+++ b/lib/Dyn/Dialect/IRDL-Eval/CMakeLists.txt
@@ -6,11 +6,6 @@ add_mlir_dialect_library(MLIRIRDLEval
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/Dyn/Dialect/IRDL-Eval
 
-        #DEPENDS
-        #MLIRIRDLEvalIncGen
-        #MLIRIRDLEvalOpsIncGen
-        #MLIRIRDLEvalTypesIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   )

--- a/lib/Dyn/Dialect/IRDL-Eval/CMakeLists.txt
+++ b/lib/Dyn/Dialect/IRDL-Eval/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_dialect_library(MLIRIRDLEval
+        IR/IRDLEval.cpp
+        IR/IRDLEvalOps.cpp
+        IRDLEvalInterpreter.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${PROJECT_SOURCE_DIR}/include/Dyn/Dialect/IRDL-Eval
+
+        #DEPENDS
+        #MLIRIRDLEvalIncGen
+        #MLIRIRDLEvalOpsIncGen
+        #MLIRIRDLEvalTypesIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  )

--- a/lib/Dyn/Dialect/IRDL-Eval/IR/IRDLEval.cpp
+++ b/lib/Dyn/Dialect/IRDL-Eval/IR/IRDLEval.cpp
@@ -1,0 +1,30 @@
+//===- IRDLEval.cpp ---------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEval.h"
+
+using namespace mlir;
+using namespace irdleval;
+
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEval.cpp.inc"
+
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEvalDialect.cpp.inc"
+
+void IRDLEvalDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.cpp.inc"
+      >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEvalTypesGen.cpp.inc"
+      >();
+}
+
+#define GET_TYPEDEF_CLASSES
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEvalTypesGen.cpp.inc"

--- a/lib/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.cpp
+++ b/lib/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.cpp
@@ -1,0 +1,113 @@
+//===- IRDLEvalOps.cpp ------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEval.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace irdlssa;
+using namespace irdleval;
+
+LogicalResult Eval_Verifier::verify() {
+  Operation *parent = this->getOperation()->getParentOp();
+  assert(parent && "verifier operation has no parent");
+
+  size_t argAmount = 0;
+  for (Operation &op : parent->getRegion(0).getOps()) {
+    if (SSA_OperandsOp operOp = llvm::dyn_cast<SSA_OperandsOp>(op)) {
+      argAmount += operOp.args().size();
+    } else if (SSA_ResultsOp resOp = llvm::dyn_cast<SSA_ResultsOp>(op)) {
+      argAmount += resOp.args().size();
+    } else if (SSA_ParametersOp paramOp =
+                   llvm::dyn_cast<SSA_ParametersOp>(op)) {
+      argAmount += paramOp.args().size();
+    }
+  }
+
+  if (this->body().getArguments().size() != argAmount) {
+    return this->emitError().append("verifier body region expected ", argAmount,
+                                    " arguments but got ",
+                                    this->body().getArguments().size());
+  }
+
+  auto args = this->body().getArguments();
+  for (size_t i = 0; i < args.size(); i++) {
+    if (!args[i].getType().isa<EvalTypeType>()) {
+      return this->emitError().append(
+          "argument ", args[i],
+          " of verifier body region is of incorrect type ", args[i].getType());
+    }
+  }
+
+  return LogicalResult::success();
+}
+
+LogicalResult Eval_Goto::verify() {
+  if (this->to()->getArguments().size() != 0) {
+    return this->emitError().append(
+        "success block expected to have 0 arguments, has ",
+        this->to()->getArguments().size());
+  }
+
+  return LogicalResult::success();
+}
+
+LogicalResult Eval_MatchType::verify() {
+  if (this->success()->getArguments().size() != 0) {
+    return this->emitError().append(
+        "success block expected to have 0 arguments, has ",
+        this->success()->getArguments().size());
+  }
+
+  if (this->failure()->getArguments().size() != 0) {
+    return this->emitError().append(
+        "failure block expected to have 0 arguments, has ",
+        this->failure()->getArguments().size());
+  }
+
+  return LogicalResult::success();
+}
+
+LogicalResult Eval_CheckType::verify() {
+  if (this->success()->getArguments().size() != 0) {
+    return this->emitError().append(
+        "success block expected to have 0 arguments, has ",
+        this->success()->getArguments().size());
+  }
+
+  if (this->failure()->getArguments().size() != 0) {
+    return this->emitError().append(
+        "failure block expected to have 0 arguments, has ",
+        this->failure()->getArguments().size());
+  }
+
+  return LogicalResult::success();
+}
+
+LogicalResult Eval_CheckParametric::verify() {
+  auto args = this->success()->getArguments();
+  for (size_t i = 0; i < args.size(); i++) {
+    if (!args[i].getType().isa<EvalTypeType>()) {
+      return this->emitError().append("success block argument ", args[i],
+                                      " is of incorrect type ",
+                                      args[i].getType());
+    }
+  }
+
+  if (this->invalidBase()->getArguments().size() != 0) {
+    return this->emitError().append(
+        "invalid base block expected to have 0 arguments, has ",
+        this->invalidBase()->getArguments().size());
+  }
+
+  return LogicalResult::success();
+}
+
+#define GET_OP_CLASSES
+#include "Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.cpp.inc"

--- a/lib/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.cpp
+++ b/lib/Dyn/Dialect/IRDL-Eval/IR/IRDLEvalOps.cpp
@@ -14,7 +14,7 @@ using namespace mlir;
 using namespace irdlssa;
 using namespace irdleval;
 
-LogicalResult Eval_Verifier::verify() {
+LogicalResult Verifier::verify() {
   Operation *parent = this->getOperation()->getParentOp();
   assert(parent && "verifier operation has no parent");
 
@@ -48,17 +48,7 @@ LogicalResult Eval_Verifier::verify() {
   return LogicalResult::success();
 }
 
-LogicalResult Eval_Goto::verify() {
-  if (this->to()->getArguments().size() != 0) {
-    return this->emitError().append(
-        "success block expected to have 0 arguments, has ",
-        this->to()->getArguments().size());
-  }
-
-  return LogicalResult::success();
-}
-
-LogicalResult Eval_MatchType::verify() {
+LogicalResult MatchType::verify() {
   if (this->success()->getArguments().size() != 0) {
     return this->emitError().append(
         "success block expected to have 0 arguments, has ",
@@ -74,7 +64,7 @@ LogicalResult Eval_MatchType::verify() {
   return LogicalResult::success();
 }
 
-LogicalResult Eval_CheckType::verify() {
+LogicalResult CheckType::verify() {
   if (this->success()->getArguments().size() != 0) {
     return this->emitError().append(
         "success block expected to have 0 arguments, has ",
@@ -90,7 +80,7 @@ LogicalResult Eval_CheckType::verify() {
   return LogicalResult::success();
 }
 
-LogicalResult Eval_CheckParametric::verify() {
+LogicalResult CheckParametric::verify() {
   auto args = this->success()->getArguments();
   for (size_t i = 0; i < args.size(); i++) {
     if (!args[i].getType().isa<EvalTypeType>()) {

--- a/lib/Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.cpp
+++ b/lib/Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.cpp
@@ -7,13 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.h"
-#include "Dyn/Dialect/IRDL-SSA/TypeWrapper.h"
+#include "Dyn/Dialect/IRDL/TypeWrapper.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/IR/ExtensibleDialect.h"
 
 using namespace mlir;
 using namespace irdleval;
 using namespace irdlssa;
+using namespace irdl;
 using Instruction = IRDLEvalInterpreter::Instruction;
 using ExecutionResult = IRDLEvalInterpreter::ExecutionResult;
 

--- a/lib/Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.cpp
+++ b/lib/Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.cpp
@@ -1,0 +1,377 @@
+//===- IRDLEvalInterpreter.cpp ----------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dyn/Dialect/IRDL-Eval/IRDLEvalInterpreter.h"
+#include "Dyn/Dialect/IRDL-SSA/TypeWrapper.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/IR/ExtensibleDialect.h"
+
+using namespace mlir;
+using namespace irdleval;
+using namespace irdlssa;
+using Instruction = IRDLEvalInterpreter::Instruction;
+using ExecutionResult = IRDLEvalInterpreter::ExecutionResult;
+
+struct GotoInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    verifier.currentBlock = gotoBlock;
+    verifier.instructionPointer = 0;
+    return ExecutionResult::progress();
+  }
+
+  GotoInstruction(size_t gotoBlock) : gotoBlock(gotoBlock) {}
+
+  size_t gotoBlock;
+};
+
+struct SuccessInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    return ExecutionResult::success();
+  }
+};
+
+struct FailureInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    return ExecutionResult::failure();
+  }
+};
+
+struct CheckTypeInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    auto typeVar = verifier.typeVariables.find(toCheck);
+    assert(typeVar != verifier.typeVariables.end() &&
+           "type variable is not initialized");
+    if (typeVar->second == expected) {
+      verifier.currentBlock = gotoOnSuccess;
+      verifier.instructionPointer = 0;
+
+    } else {
+      verifier.currentBlock = gotoOnFailure;
+      verifier.instructionPointer = 0;
+    }
+    return ExecutionResult::progress();
+  }
+
+  CheckTypeInstruction(size_t toCheck, Type expected, size_t gotoOnSuccess,
+                       size_t gotoOnFailure)
+      : toCheck(toCheck), expected(expected), gotoOnSuccess(gotoOnSuccess),
+        gotoOnFailure(gotoOnFailure) {}
+
+  size_t toCheck;
+  Type expected;
+  size_t gotoOnSuccess;
+  size_t gotoOnFailure;
+};
+
+struct CheckDynParametricInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    auto typeVar = verifier.typeVariables.find(toCheck);
+    assert(typeVar != verifier.typeVariables.end() &&
+           "type variable is not initialized");
+
+    auto dynType = typeVar->second.dyn_cast<DynamicType>();
+    if (dynType && dynType.getTypeDef() == this->expected) {
+      auto params = dynType.getParams();
+      assert(params.size() == typeVarsToDefine.size() &&
+             "type instance and type definition do not agree on type parameter "
+             "amount");
+      for (size_t i = 0; i < params.size(); i++) {
+        assert(params[i].isa<TypeAttr>() &&
+               "general attribute type parameters not supported");
+        verifier.typeVariables.insert(
+            {typeVarsToDefine[i], params[i].cast<TypeAttr>().getValue()});
+      }
+      verifier.currentBlock = gotoOnSuccess;
+      verifier.instructionPointer = 0;
+    } else {
+      verifier.currentBlock = gotoOnInvalidBase;
+      verifier.instructionPointer = 0;
+    }
+
+    return ExecutionResult::progress();
+  }
+
+  CheckDynParametricInstruction(size_t toCheck, DynamicTypeDefinition *expected,
+                                SmallVector<size_t> typeVarsToDefine,
+                                size_t gotoOnSuccess, size_t gotoOnInvalidBase)
+      : toCheck(toCheck), expected(expected),
+        typeVarsToDefine(typeVarsToDefine), gotoOnSuccess(gotoOnSuccess),
+        gotoOnInvalidBase(gotoOnInvalidBase) {}
+
+  size_t toCheck;
+  DynamicTypeDefinition *expected;
+  SmallVector<size_t> typeVarsToDefine;
+  size_t gotoOnSuccess;
+  size_t gotoOnInvalidBase;
+};
+
+struct CheckParametricInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    auto typeVar = verifier.typeVariables.find(toCheck);
+    assert(typeVar != verifier.typeVariables.end() &&
+           "type variable is not initialized");
+
+    if (this->expected->isCorrectType(typeVar->second)) {
+      auto params = this->expected->getParameters(typeVar->second);
+      assert(params.size() == typeVarsToDefine.size() &&
+             "type instance and type definition do not agree on type parameter "
+             "amount");
+      for (size_t i = 0; i < params.size(); i++) {
+        assert(params[i].isa<TypeAttr>() &&
+               "general attribute type parameters not supported");
+        verifier.typeVariables.insert(
+            {typeVarsToDefine[i], params[i].cast<TypeAttr>().getValue()});
+      }
+      verifier.currentBlock = gotoOnSuccess;
+      verifier.instructionPointer = 0;
+    } else {
+      verifier.currentBlock = gotoOnInvalidBase;
+      verifier.instructionPointer = 0;
+    }
+
+    return ExecutionResult::progress();
+  }
+
+  CheckParametricInstruction(size_t toCheck, TypeWrapper *expected,
+                             SmallVector<size_t> typeVarsToDefine,
+                             size_t gotoOnSuccess, size_t gotoOnInvalidBase)
+      : toCheck(toCheck), expected(expected),
+        typeVarsToDefine(typeVarsToDefine), gotoOnSuccess(gotoOnSuccess),
+        gotoOnInvalidBase(gotoOnInvalidBase) {}
+
+  size_t toCheck;
+  TypeWrapper *expected;
+  SmallVector<size_t> typeVarsToDefine;
+  size_t gotoOnSuccess;
+  size_t gotoOnInvalidBase;
+};
+
+struct MatchTypeInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    auto typeVar = verifier.typeVariables.find(toCheck);
+    assert(typeVar != verifier.typeVariables.end() &&
+           "type variable is not initialized");
+
+    auto slotType = verifier.slotTable.find(slot);
+    assert(slotType != verifier.slotTable.end() && "slot is not initialized");
+
+    if (typeVar->second == slotType->second) {
+      verifier.currentBlock = gotoOnSuccess;
+      verifier.instructionPointer = 0;
+    } else {
+      verifier.currentBlock = gotoOnFailure;
+      verifier.instructionPointer = 0;
+    }
+
+    return ExecutionResult::progress();
+  }
+
+  MatchTypeInstruction(size_t toCheck, size_t slot, size_t gotoOnSuccess,
+                       size_t gotoOnFailure)
+      : toCheck(toCheck), slot(slot), gotoOnSuccess(gotoOnSuccess),
+        gotoOnFailure(gotoOnFailure) {}
+
+  size_t toCheck;
+  size_t slot;
+  size_t gotoOnSuccess;
+  size_t gotoOnFailure;
+};
+
+struct AssignTypeInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    auto typeVar = verifier.typeVariables.find(toAssign);
+    assert(typeVar != verifier.typeVariables.end() &&
+           "type variable is not initialized");
+
+    verifier.slotTable.insert({slot, typeVar->second});
+
+    return ExecutionResult::progress();
+  }
+
+  AssignTypeInstruction(size_t toAssign, size_t slot)
+      : toAssign(toAssign), slot(slot) {}
+
+  size_t toAssign;
+  size_t slot;
+};
+
+struct ClearTypeInstruction : public Instruction {
+  ExecutionResult interpret(IRDLEvalInterpreter::Verifier &verifier) override {
+    verifier.slotTable.erase(slot);
+    return ExecutionResult::progress();
+  }
+
+  ClearTypeInstruction(size_t slot) : slot(slot) {}
+
+  size_t slot;
+};
+
+IRDLEvalInterpreter::Verifier IRDLEvalInterpreter::getVerifier() const {
+  DenseMap<size_t, Type> slotTable;
+  DenseMap<size_t, Type> typeVariables;
+  return IRDLEvalInterpreter::Verifier{.interpreter = *this,
+                                       .slotTable = slotTable,
+                                       .typeVariables = typeVariables};
+}
+
+LogicalResult
+IRDLEvalInterpreter::compile(llvm::function_ref<InFlightDiagnostic()> emitError,
+                             MLIRContext *ctx, Eval_Verifier op) {
+  DenseMap<Value, size_t> slotToId;
+  size_t id = 0;
+  op.walk([&](Eval_Alloca alloca) {
+    slotToId.insert({alloca.getResult(), id});
+    id++;
+  });
+
+  DenseMap<Block *, size_t> blockToId;
+  id = 0;
+  for (Block &block : op.getRegion().getBlocks()) {
+    blockToId.insert({&block, id});
+    id++;
+  }
+
+  DenseMap<Value, size_t> typeVarToId;
+  id = 0;
+  for (Block &block : op.getRegion().getBlocks()) {
+    for (Value val : block.getArguments()) {
+      typeVarToId.insert({val, id});
+      id++;
+    }
+  }
+
+  for (Value arg : op.getRegion().getArguments()) {
+    this->argTypeVariables.push_back(typeVarToId[arg]);
+  }
+
+  for (Block &block : op.getRegion().getBlocks()) {
+    SmallVector<std::unique_ptr<Instruction>> instructions;
+
+    for (Operation &op : block.getOperations()) {
+      bool fatal = false;
+      TypeSwitch<Operation *>(&op)
+          .Case([&](Eval_Goto op) {
+            instructions.push_back(
+                std::make_unique<GotoInstruction>(blockToId[op.to()]));
+          })
+          .Case([&](cf::BranchOp op) {
+            instructions.push_back(
+                std::make_unique<GotoInstruction>(blockToId[op.getDest()]));
+          })
+          .Case([&](Eval_Success op) {
+            instructions.push_back(std::make_unique<SuccessInstruction>());
+          })
+          .Case([&](Eval_Failure op) {
+            instructions.push_back(std::make_unique<FailureInstruction>());
+          })
+          .Case([&](Eval_CheckType op) {
+            Attribute instanciatedParam =
+                op.expected().instanciateParamType(emitError, *ctx);
+
+            if (!instanciatedParam) {
+              emitError().append("invalid attribute ", op.expected());
+              fatal = true;
+              return;
+            }
+
+            Type type;
+            if (TypeAttr typeAttr = instanciatedParam.dyn_cast<TypeAttr>()) {
+              type = typeAttr.getValue();
+            } else {
+              emitError().append("attribute ", op.expected(), " is not a type");
+              fatal = true;
+              return;
+            }
+
+            instructions.push_back(std::make_unique<CheckTypeInstruction>(
+                typeVarToId[op.typeVar()], type, blockToId[op.success()],
+                blockToId[op.failure()]));
+          })
+          .Case([&](Eval_CheckParametric op) {
+            SmallVector<size_t> typeVarsToDefine;
+            for (Value arg : op.success()->getArguments()) {
+              typeVarsToDefine.push_back(typeVarToId[arg]);
+            }
+
+            if (DynamicTypeDefinition *dynTypeDef =
+                    findDynamicType(*ctx, op.base())) {
+              instructions.push_back(
+                  std::make_unique<CheckDynParametricInstruction>(
+                      typeVarToId[op.typeVar()], dynTypeDef, typeVarsToDefine,
+                      blockToId[op.success()], blockToId[op.invalidBase()]));
+            } else if (TypeWrapper *typeWrapper =
+                           findTypeWrapper(*ctx, op.base())) {
+              instructions.push_back(
+                  std::make_unique<CheckParametricInstruction>(
+                      typeVarToId[op.typeVar()], typeWrapper, typeVarsToDefine,
+                      blockToId[op.success()], blockToId[op.invalidBase()]));
+
+            } else {
+              emitError().append("type ", op.base(), " not found");
+              fatal = true;
+            }
+          })
+          .Case([&](Eval_MatchType op) {
+            instructions.push_back(std::make_unique<MatchTypeInstruction>(
+                typeVarToId[op.typeVar()], slotToId[op.slot()],
+                blockToId[op.success()], blockToId[op.failure()]));
+          })
+          .Case([&](Eval_AssignType op) {
+            instructions.push_back(std::make_unique<AssignTypeInstruction>(
+                typeVarToId[op.typeVar()], slotToId[op.slot()]));
+          })
+          .Case([&](Eval_ClearType op) {
+            instructions.push_back(
+                std::make_unique<ClearTypeInstruction>(slotToId[op.slot()]));
+          })
+          .Case([&](Eval_Alloca op) {})
+          .Default([&](Operation *op) {
+            emitError().append("unsupported instruction ", op, " in verifier");
+            fatal = true;
+          });
+
+      if (fatal) {
+        return LogicalResult::failure();
+      }
+    }
+
+    this->program.insert({blockToId[&block], std::move(instructions)});
+  }
+
+  return LogicalResult::success();
+}
+
+LogicalResult IRDLEvalInterpreter::Verifier::verify(
+    llvm::function_ref<InFlightDiagnostic()> emitError, ArrayRef<Type> args) {
+  if (args.size() != this->interpreter.argTypeVariables.size()) {
+    return emitError().append("invalid amount of types, expected ",
+                              this->interpreter.argTypeVariables.size(),
+                              ", got ", args.size());
+  }
+
+  for (size_t i = 0; i < args.size(); i++) {
+    this->typeVariables.insert(
+        {this->interpreter.argTypeVariables[i], args[i]});
+  }
+
+  ExecutionResult result = ExecutionResult::progress();
+  while (!result.completed) {
+    Instruction *nextInst = (this->interpreter.program.find(this->currentBlock)
+                                 ->second)[this->instructionPointer]
+                                .get();
+    this->instructionPointer++;
+    result = nextInst->interpret(*this);
+  }
+
+  if (!result.succeeded) {
+    emitError().append(
+        "the provided types do not satisfy the type constraints");
+  }
+
+  return LogicalResult::success(result.succeeded);
+}

--- a/lib/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.cpp
+++ b/lib/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.cpp
@@ -7,13 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.h"
-#include "Dyn/Dialect/IRDL-SSA/TypeWrapper.h"
+#include "Dyn/Dialect/IRDL/TypeWrapper.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir {
 namespace irdlssa {
+
+using namespace irdl;
 
 Attribute ParamTypeInstanceAttr::parse(AsmParser &odsParser, Type odsType) {
   auto ctx = odsParser.getContext();

--- a/lib/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAOps.cpp
+++ b/lib/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAOps.cpp
@@ -8,12 +8,13 @@
 
 #include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSA.h"
 #include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSAAttributes.h"
+#include "Dyn/Dialect/IRDL/TypeWrapper.h"
 #include "mlir/Support/LogicalResult.h"
 #include <memory>
 
 using namespace mlir;
 using namespace mlir::irdlssa;
-using mlir::irdl::TypeWrapper;
+using namespace mlir::irdl;
 
 // Verifier instantiation
 Attribute

--- a/lib/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAOps.cpp
+++ b/lib/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAOps.cpp
@@ -15,34 +15,6 @@ using namespace mlir;
 using namespace mlir::irdlssa;
 using mlir::irdl::TypeWrapper;
 
-// Utils
-
-DynamicTypeDefinition *findDynamicType(MLIRContext &ctx, StringRef type) {
-  auto splitted = type.split('.');
-  auto dialectName = splitted.first;
-  auto typeName = splitted.second;
-
-  auto dialect = ctx.getOrLoadDialect(dialectName);
-  if (!dialect)
-    return nullptr;
-
-  auto extensibleDialect = llvm::dyn_cast<ExtensibleDialect>(dialect);
-  if (!extensibleDialect)
-    return nullptr;
-
-  return extensibleDialect->lookupTypeDefinition(typeName);
-}
-
-TypeWrapper *findTypeWrapper(MLIRContext &ctx, StringRef type) {
-  Dialect *irdlssaDialect = ctx.getLoadedDialect("irdlssa");
-  assert(irdlssaDialect && "irdlssa is not registered");
-
-  IRDLSSADialect *irdlssa = dyn_cast<IRDLSSADialect>(irdlssaDialect);
-  assert(irdlssa && "irdlssa dialect is not IRDL-SSA");
-
-  return irdlssa->getTypeWrapper(type);
-}
-
 // Verifier instantiation
 Attribute
 instanciateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,

--- a/lib/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAOps.cpp
+++ b/lib/Dyn/Dialect/IRDL-SSA/IR/IRDLSSAOps.cpp
@@ -17,7 +17,7 @@ using mlir::irdl::TypeWrapper;
 
 // Verifier instantiation
 Attribute
-instanciateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,
+instantiateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,
                      MLIRContext &ctx, ParamTypeAttrOrAnyAttr attr) {
   if (ParamTypeInstanceAttr typeDesc =
           attr.getAttr().dyn_cast<ParamTypeInstanceAttr>()) {
@@ -25,7 +25,7 @@ instanciateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,
 
     SmallVector<Attribute> params;
     for (ParamTypeAttrOrAnyAttr param : typeDesc.getParams()) {
-      auto result = instanciateParamType(emitError, ctx, param);
+      auto result = instantiateParamType(emitError, ctx, param);
       if (!result) {
         return Attribute();
       }
@@ -33,16 +33,16 @@ instanciateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,
     }
 
     if (DynamicTypeDefinition *type = findDynamicType(ctx, typeName)) {
-      DynamicType instanciated =
+      DynamicType instantiated =
           DynamicType::getChecked(emitError, type, params);
-      if (instanciated)
-        return TypeAttr::get(instanciated);
+      if (instantiated)
+        return TypeAttr::get(instantiated);
       else
         return Attribute();
     } else if (TypeWrapper *type = findTypeWrapper(ctx, typeName)) {
-      Type instanciated = type->instanciate(emitError, params);
-      if (instanciated)
-        return TypeAttr::get(instanciated);
+      Type instantiated = type->instantiate(emitError, params);
+      if (instantiated)
+        return TypeAttr::get(instantiated);
       else
         return Attribute();
     } else {
@@ -56,7 +56,7 @@ instanciateParamType(llvm::function_ref<InFlightDiagnostic()> emitError,
 
 llvm::Optional<std::unique_ptr<TypeConstraint>>
 SSA_IsType::getVerifier(SmallVector<Value> const &valueToConstr) {
-  auto attr = instanciateParamType([&]() { return this->emitError(); },
+  auto attr = instantiateParamType([&]() { return this->emitError(); },
                                    *this->getContext(), this->type());
 
   if (!attr)

--- a/lib/Dyn/Dialect/IRDL-SSA/TypeWrapper.cpp
+++ b/lib/Dyn/Dialect/IRDL-SSA/TypeWrapper.cpp
@@ -1,0 +1,43 @@
+//===- TypeWrapper.cpp - IRDL type wrapper definition -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dyn/Dialect/IRDL-SSA/TypeWrapper.h"
+
+#include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSA.h"
+
+namespace mlir {
+namespace irdlssa {
+
+DynamicTypeDefinition *findDynamicType(MLIRContext &ctx, StringRef type) {
+  auto splitted = type.split('.');
+  auto dialectName = splitted.first;
+  auto typeName = splitted.second;
+
+  auto dialect = ctx.getOrLoadDialect(dialectName);
+  if (!dialect)
+    return nullptr;
+
+  auto extensibleDialect = llvm::dyn_cast<ExtensibleDialect>(dialect);
+  if (!extensibleDialect)
+    return nullptr;
+
+  return extensibleDialect->lookupTypeDefinition(typeName);
+}
+
+TypeWrapper *findTypeWrapper(MLIRContext &ctx, StringRef type) {
+  Dialect *irdlssaDialect = ctx.getLoadedDialect("irdlssa");
+  assert(irdlssaDialect && "irdlssa is not registered");
+
+  IRDLSSADialect *irdlssa = dyn_cast<IRDLSSADialect>(irdlssaDialect);
+  assert(irdlssa && "irdlssa dialect is not IRDL-SSA");
+
+  return irdlssa->getTypeWrapper(type);
+}
+
+} // namespace irdlssa
+} // namespace mlir

--- a/lib/Dyn/Dialect/IRDL/CMakeLists.txt
+++ b/lib/Dyn/Dialect/IRDL/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(MLIRIRDL
         IRDLContext.cpp
         IRDLRegistration.cpp
         TypeConstraint.cpp
+        TypeWrapper.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/Dyn/Dialect/IRDL

--- a/lib/Dyn/Dialect/IRDL/TypeWrapper.cpp
+++ b/lib/Dyn/Dialect/IRDL/TypeWrapper.cpp
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Dyn/Dialect/IRDL-SSA/TypeWrapper.h"
+#include "Dyn/Dialect/IRDL/TypeWrapper.h"
 
-#include "Dyn/Dialect/IRDL-SSA/IR/IRDLSSA.h"
+#include "Dyn/Dialect/IRDL/IR/IRDL.h"
 
 namespace mlir {
-namespace irdlssa {
+namespace irdl {
 
 DynamicTypeDefinition *findDynamicType(MLIRContext &ctx, StringRef type) {
   auto splitted = type.split('.');
@@ -30,14 +30,11 @@ DynamicTypeDefinition *findDynamicType(MLIRContext &ctx, StringRef type) {
 }
 
 TypeWrapper *findTypeWrapper(MLIRContext &ctx, StringRef type) {
-  Dialect *irdlssaDialect = ctx.getLoadedDialect("irdlssa");
-  assert(irdlssaDialect && "irdlssa is not registered");
+  IRDLDialect *irdl = ctx.getLoadedDialect<IRDLDialect>();
+  assert(irdl && "irdl is not registered");
 
-  IRDLSSADialect *irdlssa = dyn_cast<IRDLSSADialect>(irdlssaDialect);
-  assert(irdlssa && "irdlssa dialect is not IRDL-SSA");
-
-  return irdlssa->getTypeWrapper(type);
+  return irdl->getTypeWrapper(type);
 }
 
-} // namespace irdlssa
+} // namespace irdl
 } // namespace mlir

--- a/test/Dyn/Eval/backtrack.irdlssa
+++ b/test/Dyn/Eval/backtrack.irdlssa
@@ -1,5 +1,6 @@
 // RUN: dyn-opt %s | dyn-opt | FileCheck %s
 
+// CHECK: module {
 module {
   // CHECK-LABEL: irdlssa.dialect backtrack {
   irdlssa.dialect backtrack {
@@ -9,7 +10,7 @@ module {
       irdlssa.parameters(%0)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %1 = irdleval.alloca
         irdleval.assign(%1, %arg0)
         irdleval.success
@@ -26,7 +27,7 @@ module {
       irdlssa.parameters(%4, %2)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type, %arg1: !irdleval.type):
         %5 = irdleval.alloca
         %6 = irdleval.alloca
         %7 = irdleval.alloca
@@ -53,7 +54,7 @@ module {
       ^bb8:  // pred: ^bb7
         irdleval.clear(%9)
         cf.br ^bb2
-      ^bb9(%10: !irdleval.eval_type):  // pred: ^bb7
+      ^bb9(%10: !irdleval.type):  // pred: ^bb7
         irdleval.assign(%8, %arg0)
         irdleval.assign(%7, %10)
         irdleval.check_type(%10, f32, ^bb4, ^bb11)
@@ -75,7 +76,7 @@ module {
       irdlssa.results(%0)
       
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %1 = irdleval.alloca
         irdleval.check_type(%arg0, f32, ^bb1, ^bb2)
       ^bb1:  // pred: ^bb0

--- a/test/Dyn/Eval/backtrack.irdlssa
+++ b/test/Dyn/Eval/backtrack.irdlssa
@@ -1,0 +1,88 @@
+// RUN: dyn-opt %s | dyn-opt | FileCheck %s
+
+module {
+  // CHECK-LABEL: irdlssa.dialect backtrack {
+  irdlssa.dialect backtrack {
+    // CHECK-LABEL: irdlssa.type parametric {
+    irdlssa.type parametric {
+      %0 = irdlssa.any_type
+      irdlssa.parameters(%0)
+
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %1 = irdleval.alloca
+        irdleval.assign(%1, %arg0)
+        irdleval.success
+      }
+    }
+
+    // CHECK-LABEL: irdlssa.type foo {
+    irdlssa.type foo {
+      %0 = irdlssa.is_type : f32
+      %1 = irdlssa.is_type : "backtrack.parametric"<f32>
+      %2 = irdlssa.any_of(%0, %1)
+      %3 = irdlssa.parametric_type : "backtrack.parametric"<%2>
+      %4 = irdlssa.any_of(%2, %3)
+      irdlssa.parameters(%4, %2)
+
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+        %5 = irdleval.alloca
+        %6 = irdleval.alloca
+        %7 = irdleval.alloca
+        %8 = irdleval.alloca
+        %9 = irdleval.alloca
+        irdleval.assign(%9, %arg0)
+        irdleval.assign(%7, %arg0)
+        irdleval.check_type(%arg0, f32, ^bb3, ^bb6)
+      ^bb1:  // 4 preds: ^bb3, ^bb4, ^bb5, ^bb10
+        irdleval.success
+      ^bb2:  // 2 preds: ^bb8, ^bb12
+        irdleval.failure
+      ^bb3:  // pred: ^bb0
+        irdleval.match_type(%7, %arg1, ^bb1, ^bb6)
+      ^bb4:  // pred: ^bb9
+        irdleval.match_type(%7, %arg1, ^bb1, ^bb11)
+      ^bb5:  // pred: ^bb6
+        irdleval.match_type(%7, %arg1, ^bb1, ^bb7)
+      ^bb6:  // 2 preds: ^bb0, ^bb3
+        irdleval.check_type(%arg0, "backtrack.parametric"<f32>, ^bb5, ^bb7)
+      ^bb7:  // 2 preds: ^bb5, ^bb6
+        irdleval.clear(%7)
+        irdleval.check_parametric(%arg0, "backtrack.parametric", ^bb9, ^bb8)
+      ^bb8:  // pred: ^bb7
+        irdleval.clear(%9)
+        cf.br ^bb2
+      ^bb9(%10: !irdleval.eval_type):  // pred: ^bb7
+        irdleval.assign(%8, %arg0)
+        irdleval.assign(%7, %10)
+        irdleval.check_type(%10, f32, ^bb4, ^bb11)
+      ^bb10:  // pred: ^bb11
+        irdleval.match_type(%7, %arg1, ^bb1, ^bb12)
+      ^bb11:  // 2 preds: ^bb4, ^bb9
+        irdleval.check_type(%10, "backtrack.parametric"<f32>, ^bb10, ^bb12)
+      ^bb12:  // 2 preds: ^bb10, ^bb11
+        irdleval.clear(%9)
+        irdleval.clear(%8)
+        irdleval.clear(%7)
+        cf.br ^bb2
+      }
+    }
+
+    // CHECK-LABEL: irdlssa.operation const {
+    irdlssa.operation const {
+      %0 = irdlssa.is_type : f32
+      irdlssa.results(%0)
+      
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %1 = irdleval.alloca
+        irdleval.check_type(%arg0, f32, ^bb1, ^bb2)
+      ^bb1:  // pred: ^bb0
+        irdleval.success
+      ^bb2:  // pred: ^bb0
+        irdleval.failure
+      }
+    }
+  }
+}

--- a/test/Dyn/Eval/cmath.irdlssa
+++ b/test/Dyn/Eval/cmath.irdlssa
@@ -1,0 +1,94 @@
+// RUN: dyn-opt %s | dyn-opt | FileCheck %s
+
+module {
+  // CHECK-LABEL: irdlssa.dialect cmath {
+  irdlssa.dialect cmath {
+    irdlssa.type complex {
+      %0 = irdlssa.is_type : f32
+      %1 = irdlssa.is_type : f64
+      %2 = irdlssa.any_of(%0, %1)
+      irdlssa.parameters(%2)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %3 = irdleval.alloca
+        %4 = irdleval.alloca
+        %5 = irdleval.alloca
+        irdleval.assign(%5, %arg0)
+        irdleval.check_type(%arg0, f32, ^bb1, ^bb2)
+      ^bb1:  // 2 preds: ^bb0, ^bb2
+        irdleval.success
+      ^bb2:  // pred: ^bb0
+        irdleval.check_type(%arg0, f64, ^bb1, ^bb3)
+      ^bb3:  // pred: ^bb2
+        irdleval.clear(%5)
+        irdleval.failure
+      }
+    }
+    irdlssa.operation norm {
+      %0 = irdlssa.any_type
+      %1 = irdlssa.parametric_type : "cmath.complex"<%0>
+      irdlssa.operands(%1)
+      irdlssa.results(%0)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+        %2 = irdleval.alloca
+        %3 = irdleval.alloca
+        irdleval.check_parametric(%arg0, "cmath.complex", ^bb4, ^bb3)
+      ^bb1:  // pred: ^bb4
+        irdleval.success
+      ^bb2:  // 2 preds: ^bb3, ^bb5
+        irdleval.failure
+      ^bb3:  // pred: ^bb0
+        cf.br ^bb2
+      ^bb4(%4: !irdleval.eval_type):  // pred: ^bb0
+        irdleval.assign(%3, %arg0)
+        irdleval.assign(%2, %4)
+        irdleval.match_type(%2, %arg1, ^bb1, ^bb5)
+      ^bb5:  // pred: ^bb4
+        irdleval.clear(%3)
+        irdleval.clear(%2)
+        cf.br ^bb2
+      }
+    }
+    irdlssa.operation mul {
+      %0 = irdlssa.is_type : f32
+      %1 = irdlssa.is_type : f64
+      %2 = irdlssa.any_of(%0, %1)
+      %3 = irdlssa.parametric_type : "cmath.complex"<%2>
+      irdlssa.operands(%3, %3)
+      irdlssa.results(%3)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type, %arg2: !irdleval.eval_type):
+        %4 = irdleval.alloca
+        %5 = irdleval.alloca
+        %6 = irdleval.alloca
+        %7 = irdleval.alloca
+        irdleval.check_parametric(%arg0, "cmath.complex", ^bb6, ^bb5)
+      ^bb1:  // 2 preds: ^bb4, ^bb7
+        irdleval.success
+      ^bb2:  // 2 preds: ^bb5, ^bb10
+        irdleval.failure
+      ^bb3:  // pred: ^bb6
+        irdleval.match_type(%7, %arg1, ^bb4, ^bb9)
+      ^bb4:  // pred: ^bb3
+        irdleval.match_type(%7, %arg2, ^bb1, ^bb9)
+      ^bb5:  // pred: ^bb0
+        cf.br ^bb2
+      ^bb6(%8: !irdleval.eval_type):  // pred: ^bb0
+        irdleval.assign(%7, %arg0)
+        irdleval.assign(%6, %8)
+        irdleval.check_type(%8, f32, ^bb3, ^bb9)
+      ^bb7:  // pred: ^bb8
+        irdleval.match_type(%7, %arg2, ^bb1, ^bb10)
+      ^bb8:  // pred: ^bb9
+        irdleval.match_type(%7, %arg1, ^bb7, ^bb10)
+      ^bb9:  // 3 preds: ^bb3, ^bb4, ^bb6
+        irdleval.check_type(%8, f64, ^bb8, ^bb10)
+      ^bb10:  // 3 preds: ^bb7, ^bb8, ^bb9
+        irdleval.clear(%7)
+        irdleval.clear(%6)
+        cf.br ^bb2
+      }
+    }
+  }
+}

--- a/test/Dyn/Eval/cmath.irdlssa
+++ b/test/Dyn/Eval/cmath.irdlssa
@@ -8,6 +8,7 @@ module {
       %1 = irdlssa.is_type : f64
       %2 = irdlssa.any_of(%0, %1)
       irdlssa.parameters(%2)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type):
         %3 = irdleval.alloca
@@ -24,11 +25,13 @@ module {
         irdleval.failure
       }
     }
+
     irdlssa.operation norm {
       %0 = irdlssa.any_type
       %1 = irdlssa.parametric_type : "cmath.complex"<%0>
       irdlssa.operands(%1)
       irdlssa.results(%0)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
         %2 = irdleval.alloca
@@ -50,6 +53,7 @@ module {
         cf.br ^bb2
       }
     }
+    
     irdlssa.operation mul {
       %0 = irdlssa.is_type : f32
       %1 = irdlssa.is_type : f64
@@ -57,6 +61,7 @@ module {
       %3 = irdlssa.parametric_type : "cmath.complex"<%2>
       irdlssa.operands(%3, %3)
       irdlssa.results(%3)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type, %arg2: !irdleval.eval_type):
         %4 = irdleval.alloca

--- a/test/Dyn/Eval/cmath.irdlssa
+++ b/test/Dyn/Eval/cmath.irdlssa
@@ -1,5 +1,6 @@
 // RUN: dyn-opt %s | dyn-opt | FileCheck %s
 
+// CHECK: module {
 module {
   // CHECK-LABEL: irdlssa.dialect cmath {
   irdlssa.dialect cmath {
@@ -10,7 +11,7 @@ module {
       irdlssa.parameters(%2)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %3 = irdleval.alloca
         %4 = irdleval.alloca
         %5 = irdleval.alloca
@@ -33,7 +34,7 @@ module {
       irdlssa.results(%0)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type, %arg1: !irdleval.type):
         %2 = irdleval.alloca
         %3 = irdleval.alloca
         irdleval.check_parametric(%arg0, "cmath.complex", ^bb4, ^bb3)
@@ -43,7 +44,7 @@ module {
         irdleval.failure
       ^bb3:  // pred: ^bb0
         cf.br ^bb2
-      ^bb4(%4: !irdleval.eval_type):  // pred: ^bb0
+      ^bb4(%4: !irdleval.type):  // pred: ^bb0
         irdleval.assign(%3, %arg0)
         irdleval.assign(%2, %4)
         irdleval.match_type(%2, %arg1, ^bb1, ^bb5)
@@ -63,7 +64,7 @@ module {
       irdlssa.results(%3)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type, %arg2: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type, %arg1: !irdleval.type, %arg2: !irdleval.type):
         %4 = irdleval.alloca
         %5 = irdleval.alloca
         %6 = irdleval.alloca
@@ -79,7 +80,7 @@ module {
         irdleval.match_type(%7, %arg2, ^bb1, ^bb9)
       ^bb5:  // pred: ^bb0
         cf.br ^bb2
-      ^bb6(%8: !irdleval.eval_type):  // pred: ^bb0
+      ^bb6(%8: !irdleval.type):  // pred: ^bb0
         irdleval.assign(%7, %arg0)
         irdleval.assign(%6, %8)
         irdleval.check_type(%8, f32, ^bb3, ^bb9)

--- a/test/Dyn/Eval/test-backtrack.mlir
+++ b/test/Dyn/Eval/test-backtrack.mlir
@@ -1,0 +1,9 @@
+// RUN: dyn-opt %s --irdlssa-file=%S/backtrack.irdlssa | FileCheck %s
+
+module {
+  // CHECK: func.func @testBt0(%[[arg:[^:]*]]: !backtrack.foo<!backtrack.parametric<f32>, f32>) -> f32 {
+  func.func @testBt0(%arg: !backtrack.foo<!backtrack.parametric<f32>, f32>) -> f32 {
+    %res = "backtrack.const" () : () -> f32
+    return %res : f32
+  }
+}

--- a/test/Dyn/Eval/test-cmath.mlir
+++ b/test/Dyn/Eval/test-cmath.mlir
@@ -1,0 +1,28 @@
+// RUN: dyn-opt %s --irdlssa-file=%S/cmath.irdlssa | dyn-opt --irdlssa-file=%S/cmath.irdlssa | FileCheck %s
+
+module {
+
+  // CHECK: func.func @conorm(%{{.*}}: !cmath.complex<f32>, %{{.*}}: !cmath.complex<f32>) -> f32 {
+  // CHECK:   %{{.*}} = "cmath.norm"(%{{.*}}) : (!cmath.complex<f32>) -> f32
+  // CHECK:   %{{.*}} = "cmath.norm"(%{{.*}}) : (!cmath.complex<f32>) -> f32
+  // CHECK:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f32
+  // CHECK:   return %{{.*}} : f32
+  // CHECK: }
+  func.func @conorm(%p: !cmath.complex<f32>, %q: !cmath.complex<f32>) -> f32 {
+    %norm_p = "cmath.norm"(%p) : (!cmath.complex<f32>) -> f32
+    %norm_q = "cmath.norm"(%q) : (!cmath.complex<f32>) -> f32
+    %pq = arith.mulf %norm_p, %norm_q : f32
+    return %pq : f32
+  }
+
+  // CHECK: func.func @conorm2(%{{.*}}: !cmath.complex<f32>, %{{.*}}: !cmath.complex<f32>) -> f32 {
+  // CHECK:   %{{.*}} = "cmath.mul"(%{{.*}}, %{{.*}}) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
+  // CHECK:   %{{.*}} = "cmath.norm"(%{{.*}}) : (!cmath.complex<f32>) -> f32
+  // CHECK:   return %{{.*}} : f32
+  // CHECK: }
+  func.func @conorm2(%p: !cmath.complex<f32>, %q: !cmath.complex<f32>) -> f32 {
+    %pq = "cmath.mul"(%p, %q) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
+    %conorm = "cmath.norm"(%pq) : (!cmath.complex<f32>) -> f32
+    return %conorm : f32
+  }
+}

--- a/test/Dyn/Eval/test-type-constraints.mlir
+++ b/test/Dyn/Eval/test-type-constraints.mlir
@@ -1,0 +1,207 @@
+// RUN: dyn-opt %s --irdlssa-file=%S/testd.irdlssa -split-input-file -verify-diagnostics | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Equality constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededEqConstraint() {
+  // CHECK: "testd.eq"() : () -> i32
+  "testd.eq"() : () -> i32
+  return
+}
+
+// -----
+
+func.func @failedEqConstraint() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.eq"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @succeededEqParamConstraint() {
+  // CHECK: "testd.eq_param"() : () -> !testd.parametric<i32>
+  "testd.eq_param"() : () -> !testd.parametric<i32>
+  return
+}
+
+// -----
+
+func.func @failedEqParamConstraint1() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.eq_param"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @failedEqParamConstraint2() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.eq_param"() : () -> !testd.parametric<i64>
+  return
+}
+
+// -----
+
+func.func @failedEqParamConstraint3() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.eq_param"() : () -> !testd.parametric<!testd.parametric<i32>>
+  return
+}
+
+// -----
+
+func.func @failedEqParamConstraint4() {
+  // expected-error@+1 {{only type attribute type parameters are currently supported}}
+  "testd.eq_param"() : () -> !testd.parametric<0xBAD>
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// AnyOf constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededAnyOfConstraint() {
+  // CHECK: "testd.anyof"() : () -> i32
+  "testd.anyof"() : () -> i32
+  // CHECK: "testd.anyof"() : () -> i64
+  "testd.anyof"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @failedAnyOfConstraint() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.anyof"() : () -> i1
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Any constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededAnyConstraint() {
+  // CHECK: "testd.any"() : () -> i32
+  "testd.any"() : () -> i32
+  // CHECK: "testd.any"() : () -> i64
+  "testd.any"() : () -> i64
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Non-dynamic parameters constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededParamsConstraint() {
+  // CHECK: "testd.params"() : () -> complex<i32>
+  "testd.params"() : () -> complex<i32>
+  // CHECK: "testd.params"() : () -> complex<i64>
+  "testd.params"() : () -> complex<i64>
+  return
+}
+
+// -----
+
+func.func @failedDynParamsConstraintBase() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.params"() : () -> i32
+  return
+}
+
+// -----
+
+func.func @failedDynParamsConstraintParam() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.params"() : () -> complex<i1>
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Dynamic base constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededDynBaseConstraint() {
+  // CHECK: "testd.dynbase"() : () -> !testd.parametric<i32>
+  "testd.dynbase"() : () -> !testd.parametric<i32>
+  // CHECK: "testd.dynbase"() : () -> !testd.parametric<i64>
+  "testd.dynbase"() : () -> !testd.parametric<i64>
+  // CHECK: "testd.dynbase"() : () -> !testd.parametric<!testd.parametric<i64>>
+  "testd.dynbase"() : () -> !testd.parametric<!testd.parametric<i64>>
+  return
+}
+
+// -----
+
+func.func @failedDynBaseConstraint() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.dynbase"() : () -> i32
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Dynamic parameters constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededDynParamsConstraint() {
+  // CHECK: "testd.dynparams"() : () -> !testd.parametric<i32>
+  "testd.dynparams"() : () -> !testd.parametric<i32>
+  // CHECK: "testd.dynparams"() : () -> !testd.parametric<i64>
+  "testd.dynparams"() : () -> !testd.parametric<i64>
+  return
+}
+
+// -----
+
+func.func @failedDynParamsConstraintBase() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.dynparams"() : () -> i32
+  return
+}
+
+// -----
+
+func.func @failedDynParamsConstraintParam() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.dynparams"() : () -> !testd.parametric<i1>
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Constraint variables
+//===----------------------------------------------------------------------===//
+
+func.func @succeededConstraintVars() {
+  // CHECK: "testd.constraint_vars"() : () -> (i32, i32)
+  "testd.constraint_vars"() : () -> (i32, i32)
+  return
+}
+
+// -----
+
+func.func @succeededConstraintVars2() {
+  // CHECK: "testd.constraint_vars"() : () -> (i64, i64)
+  "testd.constraint_vars"() : () -> (i64, i64)
+  return
+}
+
+// -----
+
+func.func @failedConstraintVars() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.constraint_vars"() : () -> (i64, i32)
+  return
+}

--- a/test/Dyn/Eval/test-type-constraints.mlir
+++ b/test/Dyn/Eval/test-type-constraints.mlir
@@ -83,6 +83,34 @@ func.func @failedAnyOfConstraint() {
 // -----
 
 //===----------------------------------------------------------------------===//
+// And constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededAndConstraint() {
+  // CHECK: "testd.and"() : () -> i64
+  "testd.and"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @failedAndConstraint1() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.and"() : () -> i1
+  return
+}
+
+// -----
+
+func.func @failedAndConstraint2() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.and"() : () -> i32
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // Any constraint
 //===----------------------------------------------------------------------===//
 

--- a/test/Dyn/Eval/test-type.irdlssa
+++ b/test/Dyn/Eval/test-type.irdlssa
@@ -1,5 +1,6 @@
 // RUN: dyn-opt %s | dyn-opt | FileCheck %s
 
+// CHECK: module {
 module {
   // CHECK-LABEL: irdlssa.dialect testd {
   irdlssa.dialect testd {
@@ -19,7 +20,7 @@ module {
       irdlssa.parameters(%0, %3)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type, %arg1: !irdleval.type):
         %4 = irdleval.alloca
         %5 = irdleval.alloca
         %6 = irdleval.alloca
@@ -44,13 +45,13 @@ module {
       irdlssa.results(%0)
 
       // CHECK: irdleval.verifier {
-      // CHECK: ^[[bb0:[^\(]*]](%[[arg0:[^:]*]]: !irdleval.eval_type):
+      // CHECK: ^[[bb0:[^\(]*]](%[[arg0:[^:]*]]: !irdleval.type):
       // CHECK:   %[[v1:[^ ]*]] = irdleval.alloca
       // CHECK:   irdleval.assign(%[[v1]], %[[arg0]])
       // CHECK:   irdleval.success
       // CHECK: }
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %1 = irdleval.alloca
         irdleval.assign(%1, %arg0)
         irdleval.success

--- a/test/Dyn/Eval/test-type.irdlssa
+++ b/test/Dyn/Eval/test-type.irdlssa
@@ -9,6 +9,7 @@ module {
         irdleval.success
       }
     }
+    
     // CHECK-LABEL: irdlssa.type parametrized {
     irdlssa.type parametrized {
       %0 = irdlssa.any_type
@@ -16,6 +17,7 @@ module {
       %2 = irdlssa.is_type : i64
       %3 = irdlssa.any_of(%1, %2)
       irdlssa.parameters(%0, %3)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
         %4 = irdleval.alloca
@@ -35,10 +37,12 @@ module {
         irdleval.failure
       }
     }
+
     // CHECK-LABEL: irdlssa.operation any {
     irdlssa.operation any {
       %0 = irdlssa.any_type
       irdlssa.results(%0)
+
       // CHECK: irdleval.verifier {
       // CHECK: ^[[bb0:[^\(]*]](%[[arg0:[^:]*]]: !irdleval.eval_type):
       // CHECK:   %[[v1:[^ ]*]] = irdleval.alloca

--- a/test/Dyn/Eval/test-type.irdlssa
+++ b/test/Dyn/Eval/test-type.irdlssa
@@ -1,0 +1,56 @@
+// RUN: dyn-opt %s | dyn-opt | FileCheck %s
+
+module {
+  // CHECK-LABEL: irdlssa.dialect testd {
+  irdlssa.dialect testd {
+    // CHECK-LABEL: irdlssa.type singleton {
+    irdlssa.type singleton {
+      irdleval.verifier {
+        irdleval.success
+      }
+    }
+    // CHECK-LABEL: irdlssa.type parametrized {
+    irdlssa.type parametrized {
+      %0 = irdlssa.any_type
+      %1 = irdlssa.is_type : i32
+      %2 = irdlssa.is_type : i64
+      %3 = irdlssa.any_of(%1, %2)
+      irdlssa.parameters(%0, %3)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+        %4 = irdleval.alloca
+        %5 = irdleval.alloca
+        %6 = irdleval.alloca
+        %7 = irdleval.alloca
+        irdleval.assign(%4, %arg0)
+        irdleval.assign(%7, %arg1)
+        irdleval.check_type(%arg1, i32, ^bb1, ^bb2)
+      ^bb1:  // 2 preds: ^bb0, ^bb2
+        irdleval.success
+      ^bb2:  // pred: ^bb0
+        irdleval.check_type(%arg1, i64, ^bb1, ^bb3)
+      ^bb3:  // pred: ^bb2
+        irdleval.clear(%4)
+        irdleval.clear(%7)
+        irdleval.failure
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation any {
+    irdlssa.operation any {
+      %0 = irdlssa.any_type
+      irdlssa.results(%0)
+      // CHECK: irdleval.verifier {
+      // CHECK: ^[[bb0:[^\(]*]](%[[arg0:[^:]*]]: !irdleval.eval_type):
+      // CHECK:   %[[v1:[^ ]*]] = irdleval.alloca
+      // CHECK:   irdleval.assign(%[[v1]], %[[arg0]])
+      // CHECK:   irdleval.success
+      // CHECK: }
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %1 = irdleval.alloca
+        irdleval.assign(%1, %arg0)
+        irdleval.success
+      }
+    }
+  }
+}

--- a/test/Dyn/Eval/test-type.mlir
+++ b/test/Dyn/Eval/test-type.mlir
@@ -1,0 +1,35 @@
+// RUN: dyn-opt %s --irdlssa-file=%S/test-type.irdlssa -split-input-file -verify-diagnostics | FileCheck %s
+
+func.func @succeededTypeVerifier() {
+    // CHECK: "testd.any"() : () -> !testd.singleton
+    "testd.any"() : () -> !testd.singleton
+
+    // CHECK-NEXT: "testd.any"() : () -> !testd.parametrized<f32, i32>
+    "testd.any"() : () -> !testd.parametrized<f32, i32>
+
+    // CHECK: "testd.any"() : () -> !testd.parametrized<i1, i64>
+    "testd.any"() : () -> !testd.parametrized<i1, i64>
+
+    return
+}
+
+// -----
+
+func.func @failedSingletonVerifier() {
+     // expected-error@+1 {{invalid amount of types, expected 0, got 1}}
+     "testd.any"() : () -> !testd.singleton<i32>
+}
+
+// -----
+
+func.func @failedParametrizedVerifierWrongNumOfArgs() {
+     // expected-error@+1 {{invalid amount of types, expected 2, got 1}}
+     "testd.any"() : () -> !testd.parametrized<i32>
+}
+
+// -----
+
+func.func @failedParametrizedVerifierWrongArgument() {
+     // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+     "testd.any"() : () -> !testd.parametrized<i32, i1>
+}

--- a/test/Dyn/Eval/testd.irdlssa
+++ b/test/Dyn/Eval/testd.irdlssa
@@ -7,6 +7,7 @@ module {
     irdlssa.type parametric {
       %0 = irdlssa.any_type
       irdlssa.parameters(%0)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type):
         %1 = irdleval.alloca
@@ -14,10 +15,12 @@ module {
         irdleval.success
       }
     }
+
     // CHECK-LABEL: irdlssa.operation eq {
     irdlssa.operation eq {
       %0 = irdlssa.is_type : i32
       irdlssa.results(%0)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type):
         %1 = irdleval.alloca
@@ -28,10 +31,12 @@ module {
         irdleval.failure
       }
     }
+
     // CHECK-LABEL: irdlssa.operation eq_param {
     irdlssa.operation eq_param {
       %0 = irdlssa.is_type : "testd.parametric"<i32>
       irdlssa.results(%0)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type):
         %1 = irdleval.alloca
@@ -42,12 +47,14 @@ module {
         irdleval.failure
       }
     }
+
     // CHECK-LABEL: irdlssa.operation anyof {
     irdlssa.operation anyof {
       %0 = irdlssa.is_type : i32
       %1 = irdlssa.is_type : i64
       %2 = irdlssa.any_of(%0, %1)
       irdlssa.results(%2)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type):
         %3 = irdleval.alloca
@@ -64,10 +71,12 @@ module {
         irdleval.failure
       }
     }
+
     // CHECK-LABEL: irdlssa.operation any {
     irdlssa.operation any {
       %0 = irdlssa.any_type
       irdlssa.results(%0)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type):
         %1 = irdleval.alloca
@@ -75,11 +84,13 @@ module {
         irdleval.success
       }
     }
+
     // CHECK-LABEL: irdlssa.operation dynbase {
     irdlssa.operation dynbase {
       %0 = irdlssa.any_type
       %1 = irdlssa.parametric_type : "testd.parametric"<%0>
       irdlssa.results(%1)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type):
         %2 = irdleval.alloca
@@ -93,6 +104,7 @@ module {
         irdleval.success
       }
     }
+
     // CHECK-LABEL: irdlssa.operation dynparams {
     irdlssa.operation dynparams {
       %0 = irdlssa.is_type : i32
@@ -100,6 +112,7 @@ module {
       %2 = irdlssa.any_of(%0, %1)
       %3 = irdlssa.parametric_type : "testd.parametric"<%2>
       irdlssa.results(%3)
+
       // CHECK: irdleval.verifier {
       // CHECK: ^[[bb0:[^\(]*]](%[[arg0:[^:]*]]: !irdleval.eval_type):
       // CHECK:   %[[v4:[^ ]*]] = irdleval.alloca
@@ -149,6 +162,7 @@ module {
         cf.br ^bb2
       }
     }
+
     // CHECK-LABEL: irdlssa.operation params {
     irdlssa.operation params {
       %0 = irdlssa.is_type : i32
@@ -156,6 +170,7 @@ module {
       %2 = irdlssa.any_of(%0, %1)
       %3 = irdlssa.parametric_type : "std.complex"<%2>
       irdlssa.results(%3)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type):
         %4 = irdleval.alloca
@@ -181,12 +196,14 @@ module {
         cf.br ^bb2
       }
     }
+
     // CHECK-LABEL: irdlssa.operation constraint_vars {
     irdlssa.operation constraint_vars {
       %0 = irdlssa.is_type : i32
       %1 = irdlssa.is_type : i64
       %2 = irdlssa.any_of(%0, %1)
       irdlssa.results(%2, %2)
+
       irdleval.verifier {
       ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
         %3 = irdleval.alloca

--- a/test/Dyn/Eval/testd.irdlssa
+++ b/test/Dyn/Eval/testd.irdlssa
@@ -1,0 +1,211 @@
+// RUN: dyn-opt %s | dyn-opt | FileCheck %s
+
+module {
+  // CHECK-LABEL: irdlssa.dialect testd {
+  irdlssa.dialect testd {
+    // CHECK-LABEL: irdlssa.type parametric {
+    irdlssa.type parametric {
+      %0 = irdlssa.any_type
+      irdlssa.parameters(%0)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %1 = irdleval.alloca
+        irdleval.assign(%1, %arg0)
+        irdleval.success
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation eq {
+    irdlssa.operation eq {
+      %0 = irdlssa.is_type : i32
+      irdlssa.results(%0)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %1 = irdleval.alloca
+        irdleval.check_type(%arg0, i32, ^bb1, ^bb2)
+      ^bb1:  // pred: ^bb0
+        irdleval.success
+      ^bb2:  // pred: ^bb0
+        irdleval.failure
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation eq_param {
+    irdlssa.operation eq_param {
+      %0 = irdlssa.is_type : "testd.parametric"<i32>
+      irdlssa.results(%0)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %1 = irdleval.alloca
+        irdleval.check_type(%arg0, "testd.parametric"<i32>, ^bb1, ^bb2)
+      ^bb1:  // pred: ^bb0
+        irdleval.success
+      ^bb2:  // pred: ^bb0
+        irdleval.failure
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation anyof {
+    irdlssa.operation anyof {
+      %0 = irdlssa.is_type : i32
+      %1 = irdlssa.is_type : i64
+      %2 = irdlssa.any_of(%0, %1)
+      irdlssa.results(%2)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %3 = irdleval.alloca
+        %4 = irdleval.alloca
+        %5 = irdleval.alloca
+        irdleval.assign(%5, %arg0)
+        irdleval.check_type(%arg0, i32, ^bb1, ^bb2)
+      ^bb1:  // 2 preds: ^bb0, ^bb2
+        irdleval.success
+      ^bb2:  // pred: ^bb0
+        irdleval.check_type(%arg0, i64, ^bb1, ^bb3)
+      ^bb3:  // pred: ^bb2
+        irdleval.clear(%5)
+        irdleval.failure
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation any {
+    irdlssa.operation any {
+      %0 = irdlssa.any_type
+      irdlssa.results(%0)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %1 = irdleval.alloca
+        irdleval.assign(%1, %arg0)
+        irdleval.success
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation dynbase {
+    irdlssa.operation dynbase {
+      %0 = irdlssa.any_type
+      %1 = irdlssa.parametric_type : "testd.parametric"<%0>
+      irdlssa.results(%1)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %2 = irdleval.alloca
+        %3 = irdleval.alloca
+        irdleval.check_parametric(%arg0, "testd.parametric", ^bb2, ^bb1)
+      ^bb1:  // pred: ^bb0
+        irdleval.failure
+      ^bb2(%4: !irdleval.eval_type):  // pred: ^bb0
+        irdleval.assign(%3, %arg0)
+        irdleval.assign(%2, %4)
+        irdleval.success
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation dynparams {
+    irdlssa.operation dynparams {
+      %0 = irdlssa.is_type : i32
+      %1 = irdlssa.is_type : i64
+      %2 = irdlssa.any_of(%0, %1)
+      %3 = irdlssa.parametric_type : "testd.parametric"<%2>
+      irdlssa.results(%3)
+      // CHECK: irdleval.verifier {
+      // CHECK: ^[[bb0:[^\(]*]](%[[arg0:[^:]*]]: !irdleval.eval_type):
+      // CHECK:   %[[v4:[^ ]*]] = irdleval.alloca
+      // CHECK:   %[[v5:[^ ]*]] = irdleval.alloca
+      // CHECK:   %[[v6:[^ ]*]] = irdleval.alloca
+      // CHECK:   %[[v7:[^ ]*]] = irdleval.alloca
+      // CHECK:   irdleval.check_parametric(%[[arg0]], "testd.parametric", ^[[bb4:[^,]*]], ^[[bb3:[^,]*]])
+      // CHECK: ^[[bb1:[^:]*]]:  // 2 preds: ^[[bb4]], ^[[bb5:.*]]
+      // CHECK:   irdleval.success
+      // CHECK: ^[[bb2:[^:]*]]:  // 2 preds: ^[[bb3]], ^[[bb6:[^:]*]]
+      // CHECK:   irdleval.failure
+      // CHECK: ^[[bb3]]:  // pred: ^[[bb0]]
+      // CHECK:   cf.br ^[[bb2]]
+      // CHECK: ^[[bb4]](%[[v8:[^:]*]]: !irdleval.eval_type):  // pred: ^[[bb0]]
+      // CHECK:   irdleval.assign(%[[v7]], %[[arg0]])
+      // CHECK:   irdleval.assign(%[[v6]], %[[v8]])
+      // CHECK:   irdleval.check_type(%[[v8]], i32, ^[[bb1]], ^[[bb5]])
+      // CHECK: ^[[bb5]]:  // pred: ^[[bb4]]
+      // CHECK:   irdleval.check_type(%[[v8]], i64, ^[[bb1]], ^[[bb6]])
+      // CHECK: ^[[bb6]]:  // pred: ^[[bb5]]
+      // CHECK:   irdleval.clear(%[[v7]])
+      // CHECK:   irdleval.clear(%[[v6]])
+      // CHECK:   cf.br ^[[bb2]]
+      // CHECK: }
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %4 = irdleval.alloca
+        %5 = irdleval.alloca
+        %6 = irdleval.alloca
+        %7 = irdleval.alloca
+        irdleval.check_parametric(%arg0, "testd.parametric", ^bb4, ^bb3)
+      ^bb1:  // 2 preds: ^bb4, ^bb5
+        irdleval.success
+      ^bb2:  // 2 preds: ^bb3, ^bb6
+        irdleval.failure
+      ^bb3:  // pred: ^bb0
+        cf.br ^bb2
+      ^bb4(%8: !irdleval.eval_type):  // pred: ^bb0
+        irdleval.assign(%7, %arg0)
+        irdleval.assign(%6, %8)
+        irdleval.check_type(%8, i32, ^bb1, ^bb5)
+      ^bb5:  // pred: ^bb4
+        irdleval.check_type(%8, i64, ^bb1, ^bb6)
+      ^bb6:  // pred: ^bb5
+        irdleval.clear(%7)
+        irdleval.clear(%6)
+        cf.br ^bb2
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation params {
+    irdlssa.operation params {
+      %0 = irdlssa.is_type : i32
+      %1 = irdlssa.is_type : i64
+      %2 = irdlssa.any_of(%0, %1)
+      %3 = irdlssa.parametric_type : "std.complex"<%2>
+      irdlssa.results(%3)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type):
+        %4 = irdleval.alloca
+        %5 = irdleval.alloca
+        %6 = irdleval.alloca
+        %7 = irdleval.alloca
+        irdleval.check_parametric(%arg0, "std.complex", ^bb4, ^bb3)
+      ^bb1:  // 2 preds: ^bb4, ^bb5
+        irdleval.success
+      ^bb2:  // 2 preds: ^bb3, ^bb6
+        irdleval.failure
+      ^bb3:  // pred: ^bb0
+        cf.br ^bb2
+      ^bb4(%8: !irdleval.eval_type):  // pred: ^bb0
+        irdleval.assign(%7, %arg0)
+        irdleval.assign(%6, %8)
+        irdleval.check_type(%8, i32, ^bb1, ^bb5)
+      ^bb5:  // pred: ^bb4
+        irdleval.check_type(%8, i64, ^bb1, ^bb6)
+      ^bb6:  // pred: ^bb5
+        irdleval.clear(%7)
+        irdleval.clear(%6)
+        cf.br ^bb2
+      }
+    }
+    // CHECK-LABEL: irdlssa.operation constraint_vars {
+    irdlssa.operation constraint_vars {
+      %0 = irdlssa.is_type : i32
+      %1 = irdlssa.is_type : i64
+      %2 = irdlssa.any_of(%0, %1)
+      irdlssa.results(%2, %2)
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+        %3 = irdleval.alloca
+        %4 = irdleval.alloca
+        %5 = irdleval.alloca
+        irdleval.assign(%5, %arg0)
+        irdleval.check_type(%arg0, i32, ^bb2, ^bb4)
+      ^bb1:  // 2 preds: ^bb2, ^bb3
+        irdleval.success
+      ^bb2:  // pred: ^bb0
+        irdleval.match_type(%5, %arg1, ^bb1, ^bb4)
+      ^bb3:  // pred: ^bb4
+        irdleval.match_type(%5, %arg1, ^bb1, ^bb5)
+      ^bb4:  // 2 preds: ^bb0, ^bb2
+        irdleval.check_type(%arg0, i64, ^bb3, ^bb5)
+      ^bb5:  // 2 preds: ^bb3, ^bb4
+        irdleval.clear(%5)
+        irdleval.failure
+      }
+    }
+  }
+}

--- a/test/Dyn/Eval/testd.irdlssa
+++ b/test/Dyn/Eval/testd.irdlssa
@@ -73,6 +73,36 @@ module {
       }
     }
 
+    // CHECK-LABEL: irdlssa.operation and {
+    irdlssa.operation and {
+      %0 = irdlssa.is_type : i32
+      %1 = irdlssa.is_type : i64
+      %2 = irdlssa.any_of(%0, %1)
+      %3 = irdlssa.and(%2, %1)
+      irdlssa.results(%3)
+      
+      irdleval.verifier {
+      ^bb0(%arg0: !irdleval.type):
+        %4 = irdleval.alloca
+        %5 = irdleval.alloca
+        %6 = irdleval.alloca
+        %7 = irdleval.alloca
+        irdleval.assign(%6, %arg0)
+        irdleval.check_type(%arg0, i32, ^bb2, ^bb4)
+      ^bb1:  // 2 preds: ^bb2, ^bb3
+        irdleval.success
+      ^bb2:  // pred: ^bb0
+        irdleval.check_type(%arg0, i64, ^bb1, ^bb4)
+      ^bb3:  // pred: ^bb4
+        irdleval.check_type(%arg0, i64, ^bb1, ^bb5)
+      ^bb4:  // 2 preds: ^bb0, ^bb2
+        irdleval.check_type(%arg0, i64, ^bb3, ^bb5)
+      ^bb5:  // 2 preds: ^bb3, ^bb4
+        irdleval.clear(%6)
+        irdleval.failure
+      }
+    }
+
     // CHECK-LABEL: irdlssa.operation any {
     irdlssa.operation any {
       %0 = irdlssa.any_type

--- a/test/Dyn/Eval/testd.irdlssa
+++ b/test/Dyn/Eval/testd.irdlssa
@@ -1,5 +1,6 @@
 // RUN: dyn-opt %s | dyn-opt | FileCheck %s
 
+// CHECK: module {
 module {
   // CHECK-LABEL: irdlssa.dialect testd {
   irdlssa.dialect testd {
@@ -9,7 +10,7 @@ module {
       irdlssa.parameters(%0)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %1 = irdleval.alloca
         irdleval.assign(%1, %arg0)
         irdleval.success
@@ -22,7 +23,7 @@ module {
       irdlssa.results(%0)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %1 = irdleval.alloca
         irdleval.check_type(%arg0, i32, ^bb1, ^bb2)
       ^bb1:  // pred: ^bb0
@@ -38,7 +39,7 @@ module {
       irdlssa.results(%0)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %1 = irdleval.alloca
         irdleval.check_type(%arg0, "testd.parametric"<i32>, ^bb1, ^bb2)
       ^bb1:  // pred: ^bb0
@@ -56,7 +57,7 @@ module {
       irdlssa.results(%2)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %3 = irdleval.alloca
         %4 = irdleval.alloca
         %5 = irdleval.alloca
@@ -78,7 +79,7 @@ module {
       irdlssa.results(%0)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %1 = irdleval.alloca
         irdleval.assign(%1, %arg0)
         irdleval.success
@@ -92,13 +93,13 @@ module {
       irdlssa.results(%1)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %2 = irdleval.alloca
         %3 = irdleval.alloca
         irdleval.check_parametric(%arg0, "testd.parametric", ^bb2, ^bb1)
       ^bb1:  // pred: ^bb0
         irdleval.failure
-      ^bb2(%4: !irdleval.eval_type):  // pred: ^bb0
+      ^bb2(%4: !irdleval.type):  // pred: ^bb0
         irdleval.assign(%3, %arg0)
         irdleval.assign(%2, %4)
         irdleval.success
@@ -114,7 +115,7 @@ module {
       irdlssa.results(%3)
 
       // CHECK: irdleval.verifier {
-      // CHECK: ^[[bb0:[^\(]*]](%[[arg0:[^:]*]]: !irdleval.eval_type):
+      // CHECK: ^[[bb0:[^\(]*]](%[[arg0:[^:]*]]: !irdleval.type):
       // CHECK:   %[[v4:[^ ]*]] = irdleval.alloca
       // CHECK:   %[[v5:[^ ]*]] = irdleval.alloca
       // CHECK:   %[[v6:[^ ]*]] = irdleval.alloca
@@ -126,7 +127,7 @@ module {
       // CHECK:   irdleval.failure
       // CHECK: ^[[bb3]]:  // pred: ^[[bb0]]
       // CHECK:   cf.br ^[[bb2]]
-      // CHECK: ^[[bb4]](%[[v8:[^:]*]]: !irdleval.eval_type):  // pred: ^[[bb0]]
+      // CHECK: ^[[bb4]](%[[v8:[^:]*]]: !irdleval.type):  // pred: ^[[bb0]]
       // CHECK:   irdleval.assign(%[[v7]], %[[arg0]])
       // CHECK:   irdleval.assign(%[[v6]], %[[v8]])
       // CHECK:   irdleval.check_type(%[[v8]], i32, ^[[bb1]], ^[[bb5]])
@@ -138,7 +139,7 @@ module {
       // CHECK:   cf.br ^[[bb2]]
       // CHECK: }
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %4 = irdleval.alloca
         %5 = irdleval.alloca
         %6 = irdleval.alloca
@@ -150,7 +151,7 @@ module {
         irdleval.failure
       ^bb3:  // pred: ^bb0
         cf.br ^bb2
-      ^bb4(%8: !irdleval.eval_type):  // pred: ^bb0
+      ^bb4(%8: !irdleval.type):  // pred: ^bb0
         irdleval.assign(%7, %arg0)
         irdleval.assign(%6, %8)
         irdleval.check_type(%8, i32, ^bb1, ^bb5)
@@ -172,7 +173,7 @@ module {
       irdlssa.results(%3)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type):
         %4 = irdleval.alloca
         %5 = irdleval.alloca
         %6 = irdleval.alloca
@@ -184,7 +185,7 @@ module {
         irdleval.failure
       ^bb3:  // pred: ^bb0
         cf.br ^bb2
-      ^bb4(%8: !irdleval.eval_type):  // pred: ^bb0
+      ^bb4(%8: !irdleval.type):  // pred: ^bb0
         irdleval.assign(%7, %arg0)
         irdleval.assign(%6, %8)
         irdleval.check_type(%8, i32, ^bb1, ^bb5)
@@ -205,7 +206,7 @@ module {
       irdlssa.results(%2, %2)
 
       irdleval.verifier {
-      ^bb0(%arg0: !irdleval.eval_type, %arg1: !irdleval.eval_type):
+      ^bb0(%arg0: !irdleval.type, %arg1: !irdleval.type):
         %3 = irdleval.alloca
         %4 = irdleval.alloca
         %5 = irdleval.alloca

--- a/test/Dyn/SSA/GenEval/test-cmath.mlir
+++ b/test/Dyn/SSA/GenEval/test-cmath.mlir
@@ -1,0 +1,28 @@
+// RUN: dyn-opt %S/../cmath.irdlssa -irdl-gen-eval | dyn-opt %s --irdlssa-file=/dev/stdin | FileCheck %s
+
+module {
+
+  // CHECK: func.func @conorm(%{{.*}}: !cmath.complex<f32>, %{{.*}}: !cmath.complex<f32>) -> f32 {
+  // CHECK:   %{{.*}} = "cmath.norm"(%{{.*}}) : (!cmath.complex<f32>) -> f32
+  // CHECK:   %{{.*}} = "cmath.norm"(%{{.*}}) : (!cmath.complex<f32>) -> f32
+  // CHECK:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f32
+  // CHECK:   return %{{.*}} : f32
+  // CHECK: }
+  func.func @conorm(%p: !cmath.complex<f32>, %q: !cmath.complex<f32>) -> f32 {
+    %norm_p = "cmath.norm"(%p) : (!cmath.complex<f32>) -> f32
+    %norm_q = "cmath.norm"(%q) : (!cmath.complex<f32>) -> f32
+    %pq = arith.mulf %norm_p, %norm_q : f32
+    return %pq : f32
+  }
+
+  // CHECK: func.func @conorm2(%{{.*}}: !cmath.complex<f32>, %{{.*}}: !cmath.complex<f32>) -> f32 {
+  // CHECK:   %{{.*}} = "cmath.mul"(%{{.*}}, %{{.*}}) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
+  // CHECK:   %{{.*}} = "cmath.norm"(%{{.*}}) : (!cmath.complex<f32>) -> f32
+  // CHECK:   return %{{.*}} : f32
+  // CHECK: }
+  func.func @conorm2(%p: !cmath.complex<f32>, %q: !cmath.complex<f32>) -> f32 {
+    %pq = "cmath.mul"(%p, %q) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
+    %conorm = "cmath.norm"(%pq) : (!cmath.complex<f32>) -> f32
+    return %conorm : f32
+  }
+}

--- a/test/Dyn/SSA/GenEval/test-type-constraints.mlir
+++ b/test/Dyn/SSA/GenEval/test-type-constraints.mlir
@@ -83,6 +83,34 @@ func.func @failedAnyOfConstraint() {
 // -----
 
 //===----------------------------------------------------------------------===//
+// And constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededAndConstraint() {
+  // CHECK: "testd.and"() : () -> i64
+  "testd.and"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @failedAndConstraint1() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.and"() : () -> i1
+  return
+}
+
+// -----
+
+func.func @failedAndConstraint2() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.and"() : () -> i32
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // Any constraint
 //===----------------------------------------------------------------------===//
 

--- a/test/Dyn/SSA/GenEval/test-type-constraints.mlir
+++ b/test/Dyn/SSA/GenEval/test-type-constraints.mlir
@@ -1,0 +1,207 @@
+// RUN: dyn-opt %S/../testd.irdlssa -irdl-gen-eval | dyn-opt %s --irdlssa-file=/dev/stdin -split-input-file -verify-diagnostics | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Equality constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededEqConstraint() {
+  // CHECK: "testd.eq"() : () -> i32
+  "testd.eq"() : () -> i32
+  return
+}
+
+// -----
+
+func.func @failedEqConstraint() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.eq"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @succeededEqParamConstraint() {
+  // CHECK: "testd.eq_param"() : () -> !testd.parametric<i32>
+  "testd.eq_param"() : () -> !testd.parametric<i32>
+  return
+}
+
+// -----
+
+func.func @failedEqParamConstraint1() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.eq_param"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @failedEqParamConstraint2() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.eq_param"() : () -> !testd.parametric<i64>
+  return
+}
+
+// -----
+
+func.func @failedEqParamConstraint3() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.eq_param"() : () -> !testd.parametric<!testd.parametric<i32>>
+  return
+}
+
+// -----
+
+func.func @failedEqParamConstraint4() {
+  // expected-error@+1 {{only type attribute type parameters are currently supported}}
+  "testd.eq_param"() : () -> !testd.parametric<0xBAD>
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// AnyOf constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededAnyOfConstraint() {
+  // CHECK: "testd.anyof"() : () -> i32
+  "testd.anyof"() : () -> i32
+  // CHECK: "testd.anyof"() : () -> i64
+  "testd.anyof"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @failedAnyOfConstraint() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.anyof"() : () -> i1
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Any constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededAnyConstraint() {
+  // CHECK: "testd.any"() : () -> i32
+  "testd.any"() : () -> i32
+  // CHECK: "testd.any"() : () -> i64
+  "testd.any"() : () -> i64
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Non-dynamic parameters constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededParamsConstraint() {
+  // CHECK: "testd.params"() : () -> complex<i32>
+  "testd.params"() : () -> complex<i32>
+  // CHECK: "testd.params"() : () -> complex<i64>
+  "testd.params"() : () -> complex<i64>
+  return
+}
+
+// -----
+
+func.func @failedDynParamsConstraintBase() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.params"() : () -> i32
+  return
+}
+
+// -----
+
+func.func @failedDynParamsConstraintParam() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.params"() : () -> complex<i1>
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Dynamic base constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededDynBaseConstraint() {
+  // CHECK: "testd.dynbase"() : () -> !testd.parametric<i32>
+  "testd.dynbase"() : () -> !testd.parametric<i32>
+  // CHECK: "testd.dynbase"() : () -> !testd.parametric<i64>
+  "testd.dynbase"() : () -> !testd.parametric<i64>
+  // CHECK: "testd.dynbase"() : () -> !testd.parametric<!testd.parametric<i64>>
+  "testd.dynbase"() : () -> !testd.parametric<!testd.parametric<i64>>
+  return
+}
+
+// -----
+
+func.func @failedDynBaseConstraint() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.dynbase"() : () -> i32
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Dynamic parameters constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededDynParamsConstraint() {
+  // CHECK: "testd.dynparams"() : () -> !testd.parametric<i32>
+  "testd.dynparams"() : () -> !testd.parametric<i32>
+  // CHECK: "testd.dynparams"() : () -> !testd.parametric<i64>
+  "testd.dynparams"() : () -> !testd.parametric<i64>
+  return
+}
+
+// -----
+
+func.func @failedDynParamsConstraintBase() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.dynparams"() : () -> i32
+  return
+}
+
+// -----
+
+func.func @failedDynParamsConstraintParam() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.dynparams"() : () -> !testd.parametric<i1>
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Constraint variables
+//===----------------------------------------------------------------------===//
+
+func.func @succeededConstraintVars() {
+  // CHECK: "testd.constraint_vars"() : () -> (i32, i32)
+  "testd.constraint_vars"() : () -> (i32, i32)
+  return
+}
+
+// -----
+
+func.func @succeededConstraintVars2() {
+  // CHECK: "testd.constraint_vars"() : () -> (i64, i64)
+  "testd.constraint_vars"() : () -> (i64, i64)
+  return
+}
+
+// -----
+
+func.func @failedConstraintVars() {
+  // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+  "testd.constraint_vars"() : () -> (i64, i32)
+  return
+}

--- a/test/Dyn/SSA/GenEval/test-type.mlir
+++ b/test/Dyn/SSA/GenEval/test-type.mlir
@@ -1,0 +1,35 @@
+// RUN: dyn-opt %S/../test-type.irdlssa -irdl-gen-eval | dyn-opt %s --irdlssa-file=/dev/stdin -split-input-file -verify-diagnostics | FileCheck %s
+
+func.func @succeededTypeVerifier() {
+    // CHECK: "testd.any"() : () -> !testd.singleton
+    "testd.any"() : () -> !testd.singleton
+
+    // CHECK-NEXT: "testd.any"() : () -> !testd.parametrized<f32, i32>
+    "testd.any"() : () -> !testd.parametrized<f32, i32>
+
+    // CHECK: "testd.any"() : () -> !testd.parametrized<i1, i64>
+    "testd.any"() : () -> !testd.parametrized<i1, i64>
+
+    return
+}
+
+// -----
+
+func.func @failedSingletonVerifier() {
+     // expected-error@+1 {{invalid amount of types, expected 0, got 1}}
+     "testd.any"() : () -> !testd.singleton<i32>
+}
+
+// -----
+
+func.func @failedParametrizedVerifierWrongNumOfArgs() {
+     // expected-error@+1 {{invalid amount of types, expected 2, got 1}}
+     "testd.any"() : () -> !testd.parametrized<i32>
+}
+
+// -----
+
+func.func @failedParametrizedVerifierWrongArgument() {
+     // expected-error@+1 {{the provided types do not satisfy the type constraints}}
+     "testd.any"() : () -> !testd.parametrized<i32, i1>
+}

--- a/test/Dyn/SSA/LowerIRDL/test-type-constraints.mlir
+++ b/test/Dyn/SSA/LowerIRDL/test-type-constraints.mlir
@@ -43,6 +43,34 @@ func.func @failedAnyOfConstraint() {
 // -----
 
 //===----------------------------------------------------------------------===//
+// And constraint
+//===----------------------------------------------------------------------===//
+
+func.func @succeededAndConstraint() {
+  // CHECK: "testd.and"() : () -> i64
+  "testd.and"() : () -> i64
+  return
+}
+
+// -----
+
+func.func @failedAndConstraint1() {
+  // expected-error@+1 {{type 'i1' does not satisfy the constraint}}
+  "testd.and"() : () -> i1
+  return
+}
+
+// -----
+
+func.func @failedAndConstraint2() {
+  // expected-error@+1 {{type 'i32' does not satisfy the constraint}}
+  "testd.and"() : () -> i32
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // Any constraint
 //===----------------------------------------------------------------------===//
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -21,7 +21,7 @@ config.name = 'DYN'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.irdl', '.mlir']
+config.suffixes = ['.irdl', '.irdlssa', '.mlir']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
See IRDL-Eval dialect documentation for context.

I am no longer 100% sure `irdleval.clear` is necessary anymore (just assign over it or don't read it if you want to assign over it). This is easy to optimize out later, but GenEval does not technically require it. Maybe other users would?
`irdleval.goto` is probably useless too as I'm using `cf.br` instead for canonicalization purposes. Unless you have a strong case with respect to bootstrapping, I think it should go too.

Also ideally we would want to move the backtrack test to IRDL-SSA once it actually works. Or not, if you feel like the direct checks in IRDL-SSA should be dropped eventually.